### PR TITLE
feat: dynamic agent selection and specialized agent catalog

### DIFF
--- a/.github/workflows/alex-pr-review.consumer.yml
+++ b/.github/workflows/alex-pr-review.consumer.yml
@@ -61,6 +61,44 @@ jobs:
             *) echo "allowed=false" >> "$GITHUB_OUTPUT" ;;
           esac
 
+      - name: Resolve agent profile
+        id: agent-profile
+        if: steps.permission.outputs.allowed == 'true'
+        uses: actions/github-script@v7
+        env:
+          DEFAULT_ALEX_AGENTS: ${{ vars.ALEX_AGENTS || 'default' }}
+          DEFAULT_ALEX_DISABLED_AGENTS: ${{ vars.ALEX_DISABLED_AGENTS || '' }}
+        with:
+          script: |
+            const body = context.payload.comment?.body || '';
+            const commandLine = body.split(/\r?\n/).find((line) => /\balex\s+review\b/i.test(line)) || '';
+
+            const clean = (value) => {
+              const trimmed = String(value || '').trim();
+              if (!trimmed) return '';
+              if (!/^[a-z0-9,_ -]+$/i.test(trimmed)) {
+                core.warning(`Perfil de agentes invalido ignorado: ${trimmed}`);
+                return '';
+              }
+              return trimmed.replace(/\s*,\s*/g, ',');
+            };
+
+            const readOption = (name) => {
+              const match = commandLine.match(new RegExp(`--${name}(?:=|\\s+)([^\\s]+)`, 'i'));
+              return match ? clean(match[1]) : '';
+            };
+
+            const agentsOption = readOption('agents');
+            const disabledOption = readOption('disable-agents');
+            const rest = commandLine.replace(/\balex\s+review\b/i, '').trim();
+            const restTokens = rest.split(/\s+/).filter(Boolean);
+            const shortcut = restTokens.length === 1 && !restTokens[0].startsWith('--')
+              ? restTokens[0]
+              : '';
+
+            core.setOutput('agents', agentsOption || clean(shortcut) || clean(process.env.DEFAULT_ALEX_AGENTS));
+            core.setOutput('disabled-agents', disabledOption || clean(process.env.DEFAULT_ALEX_DISABLED_AGENTS));
+
       - name: Checkout repository
         if: steps.permission.outputs.allowed == 'true'
         uses: actions/checkout@v4
@@ -89,32 +127,49 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
-        run: gh pr diff "${{ steps.pr.outputs.number }}" --repo "${{ github.repository }}" > pr.diff
+        run: |
+          rm -f pr.diff "$RUNNER_TEMP/alex-review.md"
+          gh pr diff "${{ steps.pr.outputs.number }}" --repo "${{ github.repository }}" > pr.diff
 
       - name: Run A.L.E.X
         if: steps.permission.outputs.allowed == 'true'
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           ALEX_MODEL: ${{ vars.ALEX_MODEL || 'gemini-2.5-pro' }}
+          ALEX_AGENTS: ${{ steps.agent-profile.outputs.agents }}
+          ALEX_DISABLED_AGENTS: ${{ steps.agent-profile.outputs.disabled-agents }}
+          REPORT_PATH: ${{ runner.temp }}/alex-review.md
         run: |
           alex ci \
             --diff-file pr.diff \
-            --output-file alex-review.md \
+            --output-file "$REPORT_PATH" \
             --format markdown \
             --project "${{ github.repository }}" \
-            --pr-number "${{ steps.pr.outputs.number }}"
+            --pr-number "${{ steps.pr.outputs.number }}" \
+            --fail-on-fail \
+            --agents "$ALEX_AGENTS" \
+            --disable-agents "$ALEX_DISABLED_AGENTS"
 
       - name: Comment review on PR
-        if: steps.permission.outputs.allowed == 'true'
+        if: always() && steps.permission.outputs.allowed == 'true'
         uses: actions/github-script@v7
         env:
           PR_NUM: ${{ steps.pr.outputs.number }}
+          REPORT_PATH: ${{ runner.temp }}/alex-review.md
         with:
           github-token: ${{ github.token }}
           script: |
             const fs = require('fs');
             const prNum = Number(process.env.PR_NUM);
-            const review = fs.readFileSync('alex-review.md', 'utf8');
+            const reportPath = process.env.REPORT_PATH;
+            const review = reportPath && fs.existsSync(reportPath)
+              ? fs.readFileSync(reportPath, 'utf8')
+              : [
+                  '# A.L.E.X Code Review',
+                  '',
+                  'A execução do review falhou antes de gerar o relatório Markdown.',
+                  `Consulte os logs do workflow run ${context.runId}.`
+                ].join('\n');
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/alex-pr-review.yml
+++ b/.github/workflows/alex-pr-review.yml
@@ -70,17 +70,65 @@ jobs:
             echo "allowed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Checkout repository
+      - name: Resolve agent profile
+        id: agent-profile
+        if: steps.permission.outputs.allowed == 'true'
+        uses: actions/github-script@v7
+        env:
+          DEFAULT_ALEX_AGENTS: ${{ vars.ALEX_AGENTS || 'default' }}
+          DEFAULT_ALEX_DISABLED_AGENTS: ${{ vars.ALEX_DISABLED_AGENTS || '' }}
+        with:
+          script: |
+            const body = context.payload.comment?.body || '';
+            const commandLine = body.split(/\r?\n/).find((line) => /\balex\s+review\b/i.test(line)) || '';
+
+            const clean = (value) => {
+              const trimmed = String(value || '').trim();
+              if (!trimmed) return '';
+              if (!/^[a-z0-9,_ -]+$/i.test(trimmed)) {
+                core.warning(`Perfil de agentes invalido ignorado: ${trimmed}`);
+                return '';
+              }
+              return trimmed.replace(/\s*,\s*/g, ',');
+            };
+
+            const readOption = (name) => {
+              const match = commandLine.match(new RegExp(`--${name}(?:=|\\s+)([^\\s]+)`, 'i'));
+              return match ? clean(match[1]) : '';
+            };
+
+            const agentsOption = readOption('agents');
+            const disabledOption = readOption('disable-agents');
+            const rest = commandLine.replace(/\balex\s+review\b/i, '').trim();
+            const restTokens = rest.split(/\s+/).filter(Boolean);
+            const shortcut = restTokens.length === 1 && !restTokens[0].startsWith('--')
+              ? restTokens[0]
+              : '';
+
+            core.setOutput('agents', agentsOption || clean(shortcut) || clean(process.env.DEFAULT_ALEX_AGENTS));
+            core.setOutput('disabled-agents', disabledOption || clean(process.env.DEFAULT_ALEX_DISABLED_AGENTS));
+
+      - name: Checkout trusted A.L.E.X source
+        if: steps.permission.outputs.allowed == 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          path: alex-tool
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Checkout PR analysis target
         if: steps.permission.outputs.allowed == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          path: pr-target
 
-      - name: Checkout PR branch
+      - name: Checkout PR branch in analysis target
         if: steps.permission.outputs.allowed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
+        working-directory: pr-target
         run: |
           set -euo pipefail
           gh pr checkout "${{ steps.pr.outputs.number }}" --repo "${{ github.repository }}"
@@ -91,13 +139,16 @@ jobs:
         with:
           node-version: '24'
           cache: npm
+          cache-dependency-path: alex-tool/package-lock.json
 
-      - name: Install dependencies
+      - name: Install trusted A.L.E.X dependencies
         if: steps.permission.outputs.allowed == 'true'
+        working-directory: alex-tool
         run: npm ci
 
-      - name: Build A.L.E.X
+      - name: Build trusted A.L.E.X
         if: steps.permission.outputs.allowed == 'true'
+        working-directory: alex-tool
         run: npm run build
 
       - name: Capture PR diff
@@ -105,8 +156,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
+        working-directory: pr-target
         run: |
           set -euo pipefail
+          rm -f pr.diff "$RUNNER_TEMP/alex-review.md"
           gh pr diff "${{ steps.pr.outputs.number }}" --repo "${{ github.repository }}" > pr.diff
 
       - name: Run A.L.E.X CI review
@@ -114,25 +167,41 @@ jobs:
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           ALEX_MODEL: ${{ vars.ALEX_MODEL || 'gemini-2.5-pro' }}
+          ALEX_AGENTS: ${{ steps.agent-profile.outputs.agents }}
+          ALEX_DISABLED_AGENTS: ${{ steps.agent-profile.outputs.disabled-agents }}
+          REPORT_PATH: ${{ runner.temp }}/alex-review.md
+        working-directory: pr-target
         run: |
-          node dist/cli.js ci \
+          node ../alex-tool/dist/cli.js ci \
             --diff-file pr.diff \
-            --output-file alex-review.md \
+            --output-file "$REPORT_PATH" \
             --format markdown \
             --project "${{ github.repository }}" \
-            --pr-number "${{ steps.pr.outputs.number }}"
+            --pr-number "${{ steps.pr.outputs.number }}" \
+            --fail-on-fail \
+            --agents "$ALEX_AGENTS" \
+            --disable-agents "$ALEX_DISABLED_AGENTS"
 
       - name: Comment review on PR
-        if: steps.permission.outputs.allowed == 'true'
+        if: always() && steps.permission.outputs.allowed == 'true'
         uses: actions/github-script@v7
         env:
           PR_NUM: ${{ steps.pr.outputs.number }}
+          REPORT_PATH: ${{ runner.temp }}/alex-review.md
         with:
           github-token: ${{ github.token }}
           script: |
             const fs = require('fs');
             const prNum = Number(process.env.PR_NUM);
-            const review = fs.readFileSync('alex-review.md', 'utf8');
+            const reportPath = process.env.REPORT_PATH;
+            const review = reportPath && fs.existsSync(reportPath)
+              ? fs.readFileSync(reportPath, 'utf8')
+              : [
+                  '# A.L.E.X Code Review',
+                  '',
+                  'A execução do review falhou antes de gerar o relatório Markdown.',
+                  `Consulte os logs do workflow run ${context.runId}.`
+                ].join('\n');
             const body = [
               review,
               '',
@@ -153,8 +222,9 @@ jobs:
             });
 
       - name: Upload report artifact
-        if: steps.permission.outputs.allowed == 'true'
+        if: always() && steps.permission.outputs.allowed == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: alex-review-pr-${{ steps.pr.outputs.number }}
-          path: alex-review.md
+          path: ${{ runner.temp }}/alex-review.md
+          if-no-files-found: ignore

--- a/BACKLOG_AGENT_TRIAGE.md
+++ b/BACKLOG_AGENT_TRIAGE.md
@@ -1,0 +1,135 @@
+# Backlog: Triagem Automatica de Agentes por Contexto
+
+Este backlog formaliza o plano para que o A.L.E.X infira automaticamente quais especialistas
+ativar com base no conteudo do diff ou arquivo analisado, sem exigir `--agents` explicito.
+
+## Objetivo
+
+Reduzir o atrito para o usuario e o custo de API em reviews rotineiras, ativando apenas os
+especialistas relevantes para o tipo de mudanca detectada, mantendo a possibilidade de
+sobrescrita manual via `--agents` e `--disable-agents`.
+
+## Decisao de Design
+
+Adotar triagem baseada em **regras locais** (sem chamada LLM adicional):
+
+- Zero custo extra de API.
+- Resultado determinístico e testavel.
+- CLI tem sempre precedencia: `--agents` sobreescreve a triagem automatica.
+- Implementada como extensao do `agent_parser.ts`, nao como novo agente.
+
+Abordagens descartadas:
+
+- **Triage LLM**: exigiria dois runners sequenciais no ADK (triage + pipeline), aumentando
+  latencia, custo e fragilidade de parsing do JSON de saida.
+- **ReAct/tool-use**: imprevisivel e inadequado para CI/CD deterministico.
+
+## Regras de Triagem Propostas
+
+Cada regra mapeia padroes de arquivo/keyword para agentes sugeridos ou removidos.
+
+### Por extensao de arquivo
+
+| Extensoes detectadas no diff | Agentes sugeridos | Agentes removidos |
+|---|---|---|
+| `.sql`, `.prisma`, `.migration.*` | `security-auditor`, `sre-agent` | — |
+| `.md`, `.mdx`, `.rst`, `.txt` | `docs-maintainer` | `security-auditor`, `sre-agent`, `business-proxy` |
+| `.yml`, `.yaml`, `Dockerfile*`, `.dockerignore` | `sre-agent`, `security-auditor` | — |
+| `.test.*`, `.spec.*`, `__tests__/**` | `test-strategist`, `clean-coder` | — |
+| `.env*`, `secrets.*`, `*.pem`, `*.key` | `security-auditor` | — |
+| `package.json`, `*.lock`, `go.sum`, `requirements.txt` | `security-auditor`, `sre-agent` | — |
+
+### Por keyword no diff (heuristica de conteudo)
+
+| Keyword/padrao | Agente sugerido |
+|---|---|
+| `password`, `secret`, `token`, `apiKey`, `credentials` | `security-auditor` |
+| `SELECT`, `INSERT`, `UPDATE`, `DELETE`, `FROM` | `security-auditor` |
+| `console.log`, `print(`, `logger.` | `observability-engineer` |
+| `catch`, `throw`, `Error(`, `exception` | `error-handling-specialist` |
+| `retry`, `timeout`, `circuit`, `backpressure` | `sre-agent`, `scalability-architect` |
+| `README`, `CHANGELOG`, `docs/`, `openapi` | `docs-maintainer` |
+
+### Comportamento padrao da triagem
+
+- Se nenhuma regra casar: usa `DEFAULT_AGENT_IDS` (comportamento atual preservado).
+- Agentes inferidos por triagem podem ser ampliados ou restringidos por `--agents` / `--disable-agents`.
+- O conjunto final NUNCA fica sem ao menos um agente do council (validacao existente no parser).
+
+## Implementacao
+
+### Fase 1: Funcao de triagem
+
+Criar `src/agents/triage.ts`:
+
+```ts
+export function inferAgentsFromContent(opts: {
+  diff?: string;
+  sourceCode?: string;
+}): AgentId[] | undefined
+```
+
+- Retorna `undefined` se nenhuma regra casar (fallback para default).
+- Retorna lista de AgentIds se regras casarem.
+- Funcao pura, sem efeitos colaterais, testavel de forma isolada.
+
+### Fase 2: Integracao no agent_parser
+
+Atualizar `resolveAgentIds` para aceitar resultado de triagem como entrada de menor
+precedencia:
+
+```ts
+resolveAgentIds({
+  agents?: string,          // CLI > env var
+  disabledAgents?: string,
+  inferredAgents?: AgentId[] // triagem automatica (menor precedencia)
+})
+```
+
+Precedencia final: `CLI --agents` > `env ALEX_AGENTS` > `inferredAgents` > `default`.
+
+### Fase 3: Integracao no CLI e orchestrator
+
+- CLI extrai `diff` e `sourceCode` antes de chamar `resolveAgents`.
+- Passa `inferredAgents` para `resolveAgentIds` apenas quando `--agents` nao foi fornecido.
+- Log informativo: `[ALEX] Triagem automatica: security-auditor, sre-agent inferidos.`
+
+### Fase 4: Testes
+
+Cobrir:
+
+- Diff so com `.md` → remove agentes de codigo, ativa `docs-maintainer`.
+- Diff com `.sql` → garante `security-auditor`.
+- Diff com keywords de auth → garante `security-auditor`.
+- Diff generico sem regra → usa `default`.
+- `--agents` sobrescreve triagem.
+- `--disable-agents` remove agente inferido.
+
+## Criterios de Aceite
+
+- Triagem nao altera comportamento quando `--agents` e fornecido.
+- Triagem nao altera comportamento quando nenhuma regra casar.
+- Log de triagem e exibido apenas quando agentes foram inferidos.
+- Council nunca fica vazio apos triagem + remocoes.
+- Funcao de triagem e pura e testavel de forma isolada.
+
+## Posicao no Plano de Entrega
+
+Este backlog e independente do PR 1 (infra de selecao) e do PR 2 (novos agentes).
+Recomenda-se implementar apos o PR 2, quando os agentes que a triagem ativara
+(ex: `docs-maintainer`, `test-strategist`) ja existirem no catalogo.
+
+Sugestao: **PR 3** — Triagem automatica.
+
+## Riscos
+
+- Regras incorretas podem silenciar agentes relevantes (ex: diff de infra sem `.yml`).
+- Manutencao das regras cresce conforme novos agentes e extensoes sao adicionados.
+- Usuario pode nao perceber que agentes foram omitidos (mitigado pelo log informativo).
+
+## Fora de Escopo
+
+- Triagem via LLM (custo e latencia).
+- Triagem aprendida historicamente por repositorio.
+- Pesos ou scores por agente.
+- UI para visualizar quais agentes foram inferidos.

--- a/BACKLOG_SPECIALIZED_AGENTS.md
+++ b/BACKLOG_SPECIALIZED_AGENTS.md
@@ -60,7 +60,17 @@ Agente proposto:
 error-handling-specialist
 ```
 
-## Fase 1: Catalogo de Agentes
+## Status
+
+Concluido. O backlog foi entregue com estes ajustes finais:
+
+- `AGENT_CATALOG` contem apenas agentes de analise configuraveis pelo usuario.
+- `REVIEWER_CATALOG` contem revisores internos, ativados automaticamente por dependencia.
+- `default` expande para o perfil padrao de agentes de analise.
+- `all` expande para todos os agentes de analise registrados.
+- Revisores nao podem ser habilitados/desabilitados diretamente pelo usuario.
+
+## Fase 1: Catalogo de Agentes [Concluido]
 
 Criar um catalogo central para os agentes:
 
@@ -95,7 +105,7 @@ Critérios de aceite:
 - `default` expande para o conjunto padrao atual.
 - Agente desconhecido falha com mensagem clara.
 
-## Fase 2: Selecao Dinamica de Agentes
+## Fase 2: Selecao Dinamica de Agentes [Concluido]
 
 Adicionar suporte a selecao por CLI:
 
@@ -119,7 +129,7 @@ Critérios de aceite:
 - Env vars funcionam em CI/CD.
 - CLI tem precedencia sobre env vars.
 
-## Fase 3: Orquestracao Dinamica
+## Fase 3: Orquestracao Dinamica [Concluido]
 
 Hoje `src/agent.ts` monta o conselho de forma estatica.
 
@@ -143,7 +153,7 @@ Critérios de aceite:
 - Consolidator recebe apenas outputKeys de agentes habilitados.
 - Reflection agents continuam funcionando sem assumir outputs ausentes.
 
-## Fase 4: API e Contratos
+## Fase 4: API e Contratos [Concluido]
 
 Adicionar controle por request:
 
@@ -160,7 +170,7 @@ Critérios de aceite:
 - Payload invalido retorna erro claro.
 - Backward compatibility mantida.
 
-## Fase 5: GitHub Actions
+## Fase 5: GitHub Actions [Concluido]
 
 Atualizar workflows:
 
@@ -184,7 +194,7 @@ Critérios de aceite:
 - Repos consumidores podem configurar perfil de review por variaveis do GitHub.
 - Ausencia de variaveis mantem comportamento atual.
 
-## Fase 6: Novos Prompts
+## Fase 6: Novos Prompts [Concluido]
 
 Adicionar prompts dedicados em `src/prompts/index.ts`.
 
@@ -202,7 +212,7 @@ Critérios de aceite:
 - Cada agente evita emitir Blocker sem contexto suficiente.
 - Cada agente tem outputKey proprio.
 
-## Fase 7: Config Persistente
+## Fase 7: Config Persistente [Concluido]
 
 Adicionar comandos opcionais:
 
@@ -214,22 +224,26 @@ alex config show
 
 Esta fase deve vir depois de CLI/env/API para evitar crescer o primeiro corte.
 
-## Fase 8: Testes
+## Fase 8: Testes [Concluido]
 
-Cobrir:
+Status: concluido em testes unitarios e de workflow.
 
-- parsing de lista de agentes;
-- expansao de `default`;
-- agente desconhecido;
-- remocao via `disabledAgents`;
-- precedencia CLI > env > config;
-- pipeline com subconjunto de agentes;
-- workflow consumidor com variaveis de agentes;
-- consolidator com outputKeys dinamicos.
+Cobertura entregue:
+
+- [x] parsing de lista de agentes;
+- [x] expansao de `default`;
+- [x] expansao de `all`;
+- [x] agente desconhecido;
+- [x] remocao via `disabledAgents`;
+- [x] precedencia CLI > env > config;
+- [x] pipeline com subconjunto de agentes;
+- [x] workflow consumidor com variaveis de agentes;
+- [x] consolidator com outputKeys dinamicos;
+- [x] revisores dependentes dos agentes habilitados.
 
 ## Plano de Entrega
 
-### PR 1: Infra de selecao
+### PR 1: Infra de selecao [Concluido]
 
 - Catalogo.
 - Parser de agentes.
@@ -238,7 +252,7 @@ Cobrir:
 - Testes.
 - Sem novos agentes.
 
-### PR 2: Novos agentes
+### PR 2: Novos agentes [Concluido]
 
 - `error-handling-specialist`.
 - `test-strategist`.
@@ -258,6 +272,5 @@ Cobrir:
 
 - UI web para selecionar agentes.
 - Pesos/prioridades configuraveis por agente.
-- Execucao condicional automatica por tipo de arquivo.
+- Execucao condicional automatica por tipo de arquivo → ver `BACKLOG_AGENT_TRIAGE.md`.
 - Perfil de review aprendido historicamente.
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# 🛡️ A.L.E.X (Advanced Logic Evaluation X-ray)
+# 🛡️ A.L.E.X (Advanced Logic Evaluation X-ray)
 
 > **Status:** ✅ Production Ready | **Engine:** Multi-Agent Reasoning (Google ADK) | **Model:** gemini-2.5-pro
 
@@ -10,54 +10,61 @@ O próprio código do A.L.E.X é validado continuamente por seus agentes (`alex 
 
 ## 🏛️ Arquitetura Multi-Agente (The Council of Agents)
 
-O A.L.E.X opera sob o padrão de **Delegação Paralela**, orquestrando um conselho de agentes especialistas coordenados via **Google ADK**.
+O A.L.E.X opera sob o padrão de **Delegação Paralela**, orquestrando um conselho de agentes especialistas coordenados via **Google ADK**. O usuário configura apenas o catálogo de agentes de análise; revisores são derivados automaticamente quando suas dependências estão presentes.
 
 ```
                     ┌─────────────────────┐
                     │  ReviewOrchestrator │  ← Ponto de entrada (CLI / API)
                     └──────────┬──────────┘
-                               │ ParallelAgent
-          ┌────────────────────┼─────────────────────┐
-          ▼                    ▼                     ▼                    ▼
-  ┌──────────────┐   ┌──────────────┐   ┌──────────────┐   ┌──────────────┐
-  │  Security    │   │  Clean Coder │   │  SRE Agent   │   │  Business    │
-  │  Auditor     │   │              │   │              │   │  Proxy       │
-  └──────┬───────┘   └──────┬───────┘   └──────┬───────┘   └──────┬───────┘
-         └──────────────────┴──────────────────┴──────────────────┘
-                                       │ Cross-Review (Reflexão)
-                    ┌──────────────────┼───────────────────┐
-                    ▼                                       ▼
-           ┌─────────────────┐                  ┌─────────────────┐
-           │ Security        │                  │ Performance     │
-           │ Reviewer        │                  │ Reviewer        │
-           └─────────────────┘                  └─────────────────┘
-                                       │
-                    ┌──────────────────▼──────────────────┐
-                    │    architect-consolidator           │
-                    │  (FinalReport: PASS / WARN / FAIL)  │
-                    └─────────────────────────────────────┘
+                               │
+                               ▼
+          ┌──────────────────────────────────────────────┐
+          │ ParallelAgent: agentes de análise ativos     │
+          │ security, quality, sre, business, tests, ... │
+          └──────────────────────┬───────────────────────┘
+                                 │
+                                 ▼
+          ┌──────────────────────────────────────────────┐
+          │ ParallelAgent: revisores derivados           │
+          │ security-reviewer, performance-reviewer      │
+          └──────────────────────┬───────────────────────┘
+                                 │
+                                 ▼
+          ┌──────────────────────────────────────────────┐
+          │ architect-consolidator                       │
+          │ FinalReport: PASS / WARN / FAIL              │
+          └──────────────────────────────────────────────┘
 ```
 
 ### 👑 The Architect (Orquestrador)
 - Extrai metadados do diff/sourceCode via parser linear O(n)
-- Delega em paralelo para os 4 especialistas
+- Delega em paralelo para os agentes habilitados no perfil
+- Executa revisores apenas quando suas dependências de agentes estão presentes
 - Consolida feedbacks conflitantes em um **veredito final único**
+- Aplica retry exponencial com jitter para falhas transitórias do provedor
 
-### 🛡️ Security Auditor
-- OWASP Top 10, Path Traversal, ReDoS, Timing Attacks
-- Detecção de vazamento de credenciais e Data Leakage
+### Agentes de Análise
 
-### 🛠️ Clean Coder
-- S.O.L.I.D, DRY, Complexidade Ciclomática
-- No-Any Policy, Contract-First Development
+| Agente | Padrão | Foco |
+| :--- | :---: | :--- |
+| `security-auditor` | Sim | OWASP Top 10, path traversal, ReDoS, timing attacks, vazamento de credenciais e data leakage |
+| `clean-coder` | Sim | S.O.L.I.D, DRY, complexidade ciclomática, No-Any Policy e Contract-First Development |
+| `sre-agent` | Sim | Memory leaks, OOM, event loop blocking, timeouts, retry, rate limiting e eficiência operacional |
+| `business-proxy` | Sim | Regras de domínio via RAG dinâmico, READMEs e documentação de arquitetura local |
+| `error-handling-specialist` | Não | Caminhos de erro, fallback seguro, resiliência e falhas recuperáveis |
+| `test-strategist` | Não | Qualidade de testes, cobertura de regressão, contratos e comportamento de CI |
+| `observability-engineer` | Não | Logs, métricas, traces, debuggability e diagnóstico sem vazamento de segredo |
+| `docs-maintainer` | Não | Documentação de produto, API, operação e superfície de comandos/configuração |
+| `scalability-architect` | Não | Escalabilidade, concorrência, batching, limites de memória e crescimento de dados |
 
-### 🚀 SRE Agent
-- Memory Leaks, OOM, Event Loop blocking
-- Resiliência: timeouts, retry, rate limiting
+### Revisores Derivados
 
-### 🧠 Business Proxy
-- Valida conformidade com regras de domínio via RAG dinâmico
-- Consome READMEs e documentação de arquitetura local
+| Revisor | Dependências | Foco |
+| :--- | :--- | :--- |
+| `security-reviewer` | `sre-agent`, `clean-coder` | Revisa achados de confiabilidade e qualidade sob a ótica de segurança |
+| `performance-reviewer` | `security-auditor`, `clean-coder` | Revisa achados de segurança e qualidade sob a ótica de performance |
+
+Use `alex review all` ou `alex review --agents all` para executar todos os agentes de análise. Revisores não são habilitados diretamente pelo usuário.
 
 ---
 
@@ -155,7 +162,7 @@ npm test
 ## 💻 Modos de Uso
 
 ### CLI — `alex review`
-Analisa as modificações locais via `git diff HEAD`. Ideal para uso antes do commit.
+Analisa as modificações locais via `git diff HEAD` e inclui arquivos novos ainda `untracked` no relatório local. Ideal para uso antes do commit.
 
 ```bash
 # Com o modelo padrão (definido em .env)
@@ -188,6 +195,40 @@ Analisa um arquivo completo estruturalmente. Ideal para validar um módulo espec
 alex analyze src/services/payment.service.ts
 ```
 
+### Perfis Dinâmicos de Agentes
+
+Por padrão, `default` mantém o conselho atual. Agentes adicionais podem ser habilitados por comando, variável de ambiente ou configuração persistente:
+
+```bash
+alex review --agents default,test-strategist,error-handling-specialist
+alex review --agents all
+alex review all
+alex ci --diff-file pr.diff --agents default,docs-maintainer --disable-agents sre-agent
+alex config set-agents default,observability-engineer
+alex config set-agents all
+alex config disable-agent docs-maintainer
+```
+
+Use `all` para rodar todos os agentes de análise registrados. Agentes opt-in disponíveis: `error-handling-specialist`, `test-strategist`, `observability-engineer`, `docs-maintainer` e `scalability-architect`.
+Agentes revisores não são configuráveis pelo usuário: eles entram automaticamente quando suas dependências existem. `security-reviewer` roda quando `sre-agent` e `clean-coder` estão ativos; `performance-reviewer` roda quando `security-auditor` e `clean-coder` estão ativos.
+
+| Agente de análise | Perfil | Foco |
+|---|---|---|
+| `security-auditor` | `default` | Vulnerabilidades, conformidade e vazamento de dados |
+| `clean-coder` | `default` | Manutenibilidade, design, DRY e contratos |
+| `sre-agent` | `default` | Performance, resiliência e eficiência operacional |
+| `business-proxy` | `default` | Regras de negócio e documentação local via RAG |
+| `error-handling-specialist` | opt-in / `all` | Fail-open/fail-closed, retries, rollback e idempotência |
+| `test-strategist` | opt-in / `all` | Cobertura, regressão, casos negativos e fragilidade de testes |
+| `observability-engineer` | opt-in / `all` | Logs, métricas, traces, correlation IDs e auditabilidade |
+| `docs-maintainer` | opt-in / `all` | README, exemplos, changelog, docs de API e runbooks |
+| `scalability-architect` | opt-in / `all` | Throughput, concorrência, filas, cache e multi-instância |
+
+| Revisor automático | Dependências | Função |
+|---|---|---|
+| `security-reviewer` | `sre-agent`, `clean-coder` | Verifica se achados de performance/qualidade introduzem risco de segurança |
+| `performance-reviewer` | `security-auditor`, `clean-coder` | Verifica se achados de segurança/qualidade introduzem gargalos |
+
 > [!NOTE]
 > **Proteções de Segurança na CLI:**
 > - Path Traversal Prevention via `fs.realpath` (anti-symlink bypass)
@@ -215,7 +256,12 @@ Content-Type: application/json
 ```json
 {
   "streamId": "uuid-opcional",
-  "metadata": { "stack": ".net", "project": "MeuProjeto" },
+  "metadata": {
+    "stack": ".net",
+    "project": "MeuProjeto",
+    "agents": ["default", "test-strategist"],
+    "disabledAgents": ["docs-maintainer"]
+  },
   "diff": "conteúdo_do_git_diff_aqui"
 }
 ```
@@ -264,8 +310,13 @@ O workflow consumidor permite acionar o A.L.E.X em PRs:
 
 - manualmente via `workflow_dispatch` informando `pr_number`;
 - por comentário contendo `alex review` no PR ou em review comments.
+- por comentário com perfil de agentes, como `alex review all`, `alex review --agents all` ou `alex review --agents default,test-strategist --disable-agents docs-maintainer`.
 
-Configure o secret `GEMINI_API_KEY` no repositório. Opcionalmente, configure a variável `ALEX_MODEL` para trocar o modelo padrão.
+Configure o secret `GEMINI_API_KEY` no repositório. Opcionalmente, configure as variáveis `ALEX_MODEL`, `ALEX_AGENTS` e `ALEX_DISABLED_AGENTS` para trocar o modelo e o perfil de agentes padrão.
+
+Para falhas transitórias do provedor, o A.L.E.X aplica retry exponencial com jitter preservando o ciclo interno do ADK. Os padrões são `ALEX_AGENT_MAX_RETRIES=2` e `ALEX_AGENT_RETRY_BASE_MS=1000`. Para evitar retry storm, perfis com múltiplos agentes não reexecutam o pipeline inteiro por padrão; use `ALEX_ALLOW_MULTI_AGENT_PIPELINE_RETRY=true` apenas se aceitar esse custo.
+
+Na API, `ALEX_API_MAX_CONCURRENT_ANALYSES` controla o backpressure global de análises simultâneas. O padrão é `2`; quando o limite é atingido, a API responde `503` com `Retry-After`.
 
 O workflow consumidor executa:
 ```bash
@@ -348,6 +399,7 @@ A.L.E.X/
 | **Trust Proxy** | Restrito a `loopback` por padrão; configurável via `TRUSTED_PROXY_CIDR` |
 | **Body Limit** | 10MB máximo; `jsonParser` aplicado **após** auth para economizar parse desnecessário |
 | **Sanitização de Diff** | `diff_sanitizer.ts` redacta secrets e arquivos sensíveis antes de enviar ao LLM |
+| **Limite de Confiança do LLM** | Código, diffs e comentários analisados são tratados como conteúdo não confiável; instruções embutidas nesses inputs não devem substituir prompts do sistema |
 | **Imutabilidade** | Orquestrador cria `normalizedInput` via spread — sem mutação do payload original |
 
 > [!WARNING]

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,7 +1,10 @@
 import { LlmAgent, ParallelAgent, SequentialAgent } from '@google/adk';
 import { Schema, Type } from '@google/genai';
-import { getSecurityAuditor, getCleanCoder, getSreAgent, getBusinessProxy, getSecurityReviewer, getPerformanceReviewer } from './agents/specialists.js';
 import { getDefaultModel } from './config.js';
+import { AgentId, AGENT_BY_ID, DEFAULT_AGENT_IDS, AgentDefinition, REVIEWER_CATALOG } from './agents/catalog.js';
+import { buildArchitectConsolidatorInstruction } from './prompts/index.js';
+
+// ─── Final Report Schema ───────────────────────────────────────────────────────
 
 const finalReportSchema: Schema = {
   type: Type.OBJECT,
@@ -40,24 +43,58 @@ const finalReportSchema: Schema = {
   required: ['streamId', 'verdict', 'summary', 'issues', 'timestamp']
 };
 
-export const createRootAgent = (model: string = getDefaultModel()) => {
+// ─── Options ──────────────────────────────────────────────────────────────────
+
+export interface CreateRootAgentOpts {
   /**
-   * 1. Definindo o Conselho de Especialistas (Execução Paralela)
+   * IDs dos agentes a incluir no pipeline.
+   * Se omitido, usa DEFAULT_AGENT_IDS (comportamento original).
+   */
+  enabledAgents?: AgentId[];
+}
+
+// ─── Factory ──────────────────────────────────────────────────────────────────
+
+export const createRootAgent = (
+  model: string = getDefaultModel(),
+  opts: CreateRootAgentOpts = {},
+) => {
+  const enabledIds = opts.enabledAgents ?? [...DEFAULT_AGENT_IDS];
+
+  // Resolve definições na ordem do catálogo (preserva determinismo)
+  const enabledDefs = enabledIds
+    .map((id) => AGENT_BY_ID.get(id))
+    .filter((def): def is AgentDefinition => def !== undefined);
+
+  const enabledAgentIds = new Set(enabledDefs.map((d) => d.id));
+  const reflectionDefs = REVIEWER_CATALOG.filter((reviewer) => (
+    reviewer.requiresAgentIds.every((id) => enabledAgentIds.has(id))
+  ));
+
+  /**
+   * 1. Conselho de Especialistas (Execução Paralela)
    */
   const councilParallel = new ParallelAgent({
     name: 'council-parallel',
     description: 'Executa a análise de todos os especialistas simultaneamente.',
-    subAgents: [getSecurityAuditor(model), getCleanCoder(model), getSreAgent(model), getBusinessProxy(model)],
+    subAgents: enabledDefs.map((d) => d.factory(model)),
   });
 
   /**
-   * 2. Fase de Reflexão (Cross-Review Paralelo)
+   * 2. Instrução do Consolidator gerada dinamicamente a partir dos agentes ativos.
    */
-  const reflectionParallel = new ParallelAgent({
-    name: 'reflection-parallel',
-    description: 'Especialistas revisam os achados uns dos outros.',
-    subAgents: [getSecurityReviewer(model), getPerformanceReviewer(model)],
-  });
+  const councilSection = enabledDefs
+    .map((d) => `- ${d.label}: {${d.outputKey}?}`)
+    .join('\n');
+
+  const reflectionSection = reflectionDefs.length > 0
+    ? reflectionDefs.map((d) => `- ${d.label}: {${d.outputKey}?}`).join('\n')
+    : '(fase de reflexão desabilitada para este perfil)';
+
+  const consolidatorInstruction = buildArchitectConsolidatorInstruction(
+    councilSection,
+    reflectionSection,
+  );
 
   /**
    * 3. Agente de Consolidação (The Architect)
@@ -66,30 +103,29 @@ export const createRootAgent = (model: string = getDefaultModel()) => {
     name: 'architect-consolidator',
     model: model,
     description: 'Consolida o relatório final.',
-    instruction: `Você é o "Architect". Sua missão é consolidar o relatório final em JSON estrito.
-Analise os achados iniciais e as críticas da fase de reflexão injetados abaixo.
-Resolva conflitos e emita o veredito (PASS, FAIL, WARN). Se houver apontamentos com severidade Blocker, o veredito deve ser FAIL.
-
-**Resultados do Conselho Paralelo:**
-- Segurança: {security_findings?}
-- Qualidade: {quality_findings?}
-- Performance: {performance_findings?}
-- Negócios: {business_findings?}
-
-**Resultados da Reflexão (Críticas):**
-- Revisão de Segurança: {security_critique?}
-- Revisão de Performance: {performance_critique?}
-`,
+    instruction: consolidatorInstruction,
     outputSchema: finalReportSchema,
   });
 
   /**
-   * 4. Pipeline Principal
-   * Triage -> Parallel Analysis -> Reflection -> Consolidation
+   * 4. Pipeline Principal — reflection é incluída apenas se houver reviewers ativos.
    */
+  const pipelineStages: (ParallelAgent | LlmAgent)[] = [councilParallel];
+
+  if (reflectionDefs.length > 0) {
+    const reflectionParallel = new ParallelAgent({
+      name: 'reflection-parallel',
+      description: 'Especialistas revisam os achados uns dos outros.',
+      subAgents: reflectionDefs.map((d) => d.factory(model)),
+    });
+    pipelineStages.push(reflectionParallel);
+  }
+
+  pipelineStages.push(consolidator);
+
   return new SequentialAgent({
     name: 'alex-orchestrator-pipeline',
     description: 'Workflow completo com reflexão do A.L.E.X.',
-    subAgents: [councilParallel, reflectionParallel, consolidator],
+    subAgents: pipelineStages,
   });
 };

--- a/src/agents/agent_parser.ts
+++ b/src/agents/agent_parser.ts
@@ -1,0 +1,126 @@
+import {
+  AgentId,
+  ALL_AGENT_IDS,
+  DEFAULT_AGENT_IDS,
+  VALID_AGENT_IDS,
+} from './catalog.js';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface AgentSelectionOpts {
+  /**
+   * Lista de IDs (vírgula) ou `"default"` para expandir o conjunto padrão.
+   * Pode misturar `"default"` com IDs específicos: `"default,test-strategist"`.
+   * Se omitido, usa DEFAULT_AGENT_IDS.
+   */
+  agents?: string;
+  /**
+   * Lista de IDs (vírgula) a remover do conjunto final.
+   * IDs não presentes no conjunto são ignorados silenciosamente.
+   */
+  disabledAgents?: string;
+}
+
+// ─── Parser ───────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve a lista final de AgentIds a partir das opções de seleção.
+ *
+ * Precedência: a função não decide precedência CLI vs env — isso é
+ * responsabilidade do chamador, que deve passar o valor correto em `opts`.
+ *
+ * @throws {Error} Se um ID desconhecido for fornecido na lista de habilitados.
+ * @throws {Error} Se nenhum agente do tipo `council` restar após remoções.
+ */
+export function resolveAgentIds(opts: AgentSelectionOpts = {}): AgentId[] {
+  // 1. Expandir a lista de agentes habilitados
+  const enabledIds = expandAgentList(opts.agents);
+
+  // 2. Aplicar remoções
+  const disabledIds = parseIdList(opts.disabledAgents ?? '');
+  const finalIds = enabledIds.filter((id) => !disabledIds.includes(id));
+
+  // 3. Garantir que ao menos um agente de analise esta presente.
+  if (finalIds.length === 0) {
+    throw new Error(
+      'Selecao invalida: nenhum agente de analise restou apos aplicar --disable-agents. ' +
+        'O A.L.E.X requer ao menos um dos agentes: ' +
+        [...DEFAULT_AGENT_IDS].join(', ') +
+        '.',
+    );
+  }
+
+  return finalIds;
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Expande a string de agentes (com suporte ao token `default`) para
+ * um array de AgentIds sem duplicatas, mantendo ordem de aparição.
+ *
+ * Aceita vírgula e/ou espaço como separadores, tornando o comportamento
+ * robusto em shells como PowerShell que convertem `a,b` em `"a b"`.
+ */
+function expandAgentList(raw?: string): AgentId[] {
+  if (!raw || !raw.trim()) {
+    return [...DEFAULT_AGENT_IDS] as AgentId[];
+  }
+
+  // Normaliza: substitui vírgulas por espaços e depois faz split por whitespace
+  const tokens = raw
+    .replace(/,/g, ' ')
+    .split(/\s+/)
+    .map((t) => t.trim())
+    .filter(Boolean);
+
+  const expanded: AgentId[] = [];
+  const seen = new Set<AgentId>();
+
+  const push = (id: AgentId) => {
+    if (!seen.has(id)) {
+      seen.add(id);
+      expanded.push(id);
+    }
+  };
+
+  for (const token of tokens) {
+    if (token === 'default') {
+      for (const id of DEFAULT_AGENT_IDS) {
+        push(id as AgentId);
+      }
+    } else if (token === 'all') {
+      for (const id of ALL_AGENT_IDS) {
+        push(id as AgentId);
+      }
+    } else {
+      if (!VALID_AGENT_IDS.has(token)) {
+        throw new Error(
+          `Agente desconhecido: "${token}". ` +
+            `IDs válidos: ${[...VALID_AGENT_IDS].join(', ')}.`,
+        );
+      }
+      push(token as AgentId);
+    }
+  }
+
+  return expanded;
+}
+
+/**
+ * Converte uma string de IDs separados por vírgula e/ou espaço em AgentId[].
+ * IDs desconhecidos em listas de remoção são ignorados silenciosamente
+ * (evita falha quando um agente ainda não existe no perfil atual).
+ */
+function parseIdList(raw: string): AgentId[] {
+  if (!raw.trim()) return [];
+  return raw
+    .replace(/,/g, ' ')
+    .split(/\s+/)
+    .map((t) => t.trim())
+    .filter(Boolean)
+    .filter((token) => VALID_AGENT_IDS.has(token))
+    .map((token) => {
+      return token as AgentId;
+    });
+}

--- a/src/agents/catalog.ts
+++ b/src/agents/catalog.ts
@@ -1,0 +1,143 @@
+import { LlmAgent } from '@google/adk';
+import {
+  getSecurityAuditor,
+  getCleanCoder,
+  getSreAgent,
+  getBusinessProxy,
+  getErrorHandlingSpecialist,
+  getTestStrategist,
+  getObservabilityEngineer,
+  getDocsMaintainer,
+  getScalabilityArchitect,
+  getSecurityReviewer,
+  getPerformanceReviewer,
+} from './specialists.js';
+
+export type AgentId =
+  | 'security-auditor'
+  | 'clean-coder'
+  | 'sre-agent'
+  | 'business-proxy'
+  | 'error-handling-specialist'
+  | 'test-strategist'
+  | 'observability-engineer'
+  | 'docs-maintainer'
+  | 'scalability-architect';
+
+export type ReviewerId =
+  | 'security-reviewer'
+  | 'performance-reviewer';
+
+export interface AgentDefinition {
+  id: AgentId;
+  label: string;
+  defaultEnabled: boolean;
+  outputKey: string;
+  factory: (model: string) => LlmAgent;
+}
+
+export interface ReviewerDefinition {
+  id: ReviewerId;
+  label: string;
+  outputKey: string;
+  requiresAgentIds: ReadonlyArray<AgentId>;
+  factory: (model: string) => LlmAgent;
+}
+
+export const AGENT_CATALOG: ReadonlyArray<AgentDefinition> = [
+  {
+    id: 'security-auditor',
+    label: 'Seguranca',
+    defaultEnabled: true,
+    outputKey: 'security_findings',
+    factory: getSecurityAuditor,
+  },
+  {
+    id: 'clean-coder',
+    label: 'Qualidade',
+    defaultEnabled: true,
+    outputKey: 'quality_findings',
+    factory: getCleanCoder,
+  },
+  {
+    id: 'sre-agent',
+    label: 'Performance',
+    defaultEnabled: true,
+    outputKey: 'performance_findings',
+    factory: getSreAgent,
+  },
+  {
+    id: 'business-proxy',
+    label: 'Negocios',
+    defaultEnabled: true,
+    outputKey: 'business_findings',
+    factory: getBusinessProxy,
+  },
+  {
+    id: 'error-handling-specialist',
+    label: 'Tratamento de Erros',
+    defaultEnabled: false,
+    outputKey: 'error_handling_findings',
+    factory: getErrorHandlingSpecialist,
+  },
+  {
+    id: 'test-strategist',
+    label: 'Testes',
+    defaultEnabled: false,
+    outputKey: 'test_findings',
+    factory: getTestStrategist,
+  },
+  {
+    id: 'observability-engineer',
+    label: 'Observabilidade',
+    defaultEnabled: false,
+    outputKey: 'observability_findings',
+    factory: getObservabilityEngineer,
+  },
+  {
+    id: 'docs-maintainer',
+    label: 'Documentacao',
+    defaultEnabled: false,
+    outputKey: 'docs_findings',
+    factory: getDocsMaintainer,
+  },
+  {
+    id: 'scalability-architect',
+    label: 'Escalabilidade',
+    defaultEnabled: false,
+    outputKey: 'scalability_findings',
+    factory: getScalabilityArchitect,
+  },
+] as const;
+
+export const REVIEWER_CATALOG: ReadonlyArray<ReviewerDefinition> = [
+  {
+    id: 'security-reviewer',
+    label: 'Revisao de Seguranca',
+    outputKey: 'security_critique',
+    requiresAgentIds: ['sre-agent', 'clean-coder'],
+    factory: getSecurityReviewer,
+  },
+  {
+    id: 'performance-reviewer',
+    label: 'Revisao de Performance',
+    outputKey: 'performance_critique',
+    requiresAgentIds: ['security-auditor', 'clean-coder'],
+    factory: getPerformanceReviewer,
+  },
+] as const;
+
+export const DEFAULT_AGENT_IDS: ReadonlyArray<AgentId> = AGENT_CATALOG
+  .filter((a) => a.defaultEnabled)
+  .map((a) => a.id);
+
+export const ALL_AGENT_IDS: ReadonlyArray<AgentId> = AGENT_CATALOG
+  .map((a) => a.id);
+
+export const AGENT_BY_ID: ReadonlyMap<AgentId, AgentDefinition> = new Map(
+  AGENT_CATALOG.map((a) => [a.id, a]),
+);
+
+export const VALID_AGENT_IDS: ReadonlySet<string> = new Set(
+  AGENT_CATALOG.map((a) => a.id),
+);

--- a/src/agents/retry_policy.ts
+++ b/src/agents/retry_policy.ts
@@ -1,0 +1,60 @@
+const DEFAULT_MAX_RETRIES = 2;
+const DEFAULT_BASE_DELAY_MS = 1_000;
+const MAX_CONFIGURED_RETRIES = 5;
+const TRANSIENT_STATUS_CODES = new Set(['429', '500', '502', '503', '504']);
+
+function readBoundedInteger(value: string | undefined, fallback: number, max: number): number {
+  if (value === undefined || value.trim() === '') return fallback;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback;
+  return Math.min(parsed, max);
+}
+
+export function getAgentRetryConfig(): { maxRetries: number; baseDelayMs: number } {
+  return {
+    maxRetries: readBoundedInteger(process.env.ALEX_AGENT_MAX_RETRIES, DEFAULT_MAX_RETRIES, MAX_CONFIGURED_RETRIES),
+    baseDelayMs: readBoundedInteger(process.env.ALEX_AGENT_RETRY_BASE_MS, DEFAULT_BASE_DELAY_MS, 60_000),
+  };
+}
+
+export function getPipelineRetryConfig(activeAgentCount: number): { maxRetries: number; baseDelayMs: number } {
+  const config = getAgentRetryConfig();
+  const allowMultiAgentRetry = process.env.ALEX_ALLOW_MULTI_AGENT_PIPELINE_RETRY === 'true';
+  if (activeAgentCount > 1 && !allowMultiAgentRetry) {
+    return { ...config, maxRetries: 0 };
+  }
+
+  return config;
+}
+
+export function isTransientAgentError(errorCode?: string, errorMessage?: string): boolean {
+  const haystack = `${errorCode || ''} ${errorMessage || ''}`.toLowerCase();
+  if (!haystack.trim()) return false;
+
+  if (TRANSIENT_STATUS_CODES.has(String(errorCode))) return true;
+  return [
+    'too many requests',
+    'rate limit',
+    'timeout',
+    'timed out',
+    'temporarily unavailable',
+    'service unavailable',
+    'bad gateway',
+    'gateway timeout',
+    'internal server error',
+    'econnreset',
+    'etimedout',
+    'fetch failed',
+    'socket hang up',
+  ].some((pattern) => haystack.includes(pattern));
+}
+
+export function getRetryDelayMs(attempt: number, baseDelayMs: number): number {
+  const exponential = baseDelayMs * 2 ** Math.max(0, attempt - 1);
+  const jitter = Math.floor(Math.random() * Math.max(1, Math.floor(baseDelayMs * 0.25)));
+  return exponential + jitter;
+}
+
+export function sleepForRetry(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/agents/specialists.ts
+++ b/src/agents/specialists.ts
@@ -1,11 +1,15 @@
 import { LlmAgent } from '@google/adk';
-
 import { searchLocalRules } from '../tools/rag_tools.js';
 import {
   SECURITY_AUDITOR_PROMPT,
   CLEAN_CODER_PROMPT,
   SRE_AGENT_PROMPT,
   BUSINESS_PROXY_PROMPT,
+  ERROR_HANDLING_SPECIALIST_PROMPT,
+  TEST_STRATEGIST_PROMPT,
+  OBSERVABILITY_ENGINEER_PROMPT,
+  DOCS_MAINTAINER_PROMPT,
+  SCALABILITY_ARCHITECT_PROMPT,
   SECURITY_REVIEWER_PROMPT,
   PERFORMANCE_REVIEWER_PROMPT
 } from '../prompts/index.js';
@@ -61,6 +65,46 @@ export const getBusinessProxy = (model: string) => new LlmAgent({
 /**
  * AGENTES DE REFLEXÃO (REVIEWERS)
  */
+
+export const getErrorHandlingSpecialist = (model: string) => new LlmAgent({
+  name: 'error-handling-specialist',
+  model: model,
+  description: 'Especialista em caminhos de erro, resiliencia e falhas seguras.',
+  instruction: ERROR_HANDLING_SPECIALIST_PROMPT,
+  outputKey: 'error_handling_findings',
+});
+
+export const getTestStrategist = (model: string) => new LlmAgent({
+  name: 'test-strategist',
+  model: model,
+  description: 'Especialista em qualidade de testes e cobertura de regressao.',
+  instruction: TEST_STRATEGIST_PROMPT,
+  outputKey: 'test_findings',
+});
+
+export const getObservabilityEngineer = (model: string) => new LlmAgent({
+  name: 'observability-engineer',
+  model: model,
+  description: 'Especialista em logs, metricas, traces e debuggability.',
+  instruction: OBSERVABILITY_ENGINEER_PROMPT,
+  outputKey: 'observability_findings',
+});
+
+export const getDocsMaintainer = (model: string) => new LlmAgent({
+  name: 'docs-maintainer',
+  model: model,
+  description: 'Especialista em documentacao de produto, API e operacao.',
+  instruction: DOCS_MAINTAINER_PROMPT,
+  outputKey: 'docs_findings',
+});
+
+export const getScalabilityArchitect = (model: string) => new LlmAgent({
+  name: 'scalability-architect',
+  model: model,
+  description: 'Especialista em escalabilidade, concorrencia e crescimento de dados.',
+  instruction: SCALABILITY_ARCHITECT_PROMPT,
+  outputKey: 'scalability_findings',
+});
 
 export const getSecurityReviewer = (model: string) => new LlmAgent({
   name: 'security-reviewer',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,9 @@ import { extractCodeMetadata } from './tools/diff_tools.js';
 import { sanitizeDiff } from './utils/diff_sanitizer.js';
 import { isBlockedSensitivePath } from './utils/sensitive_paths.js';
 import { formatReportMarkdown } from './utils/report_formatter.js';
+import { resolveAgentIds } from './agents/agent_parser.js';
+import { AgentId } from './agents/catalog.js';
+import { LlmResultParseError } from './errors.js';
 
 /** Lê o git diff via spawn com stream limitado a evitar OOM/DoS */
 const MAX_DIFF_BYTES = 10 * 1024 * 1024;  // 10MB stdout
@@ -24,14 +27,59 @@ const MAX_CONTEXT_FILE_BYTES = 256 * 1024;
 const MAX_CONTEXT_TOTAL_BYTES = 2 * 1024 * 1024;
 const MAX_CONTEXT_FILES = 50;
 const GIT_DIFF_TIMEOUT_MS = 30_000;
+const MAX_RAW_RESULT_LOG_BYTES = 16 * 1024;
+const MAX_UNTRACKED_DIFF_FILE_BYTES = 256 * 1024;
+const MAX_UNTRACKED_FILES = 100;
+const MAX_UNTRACKED_LIST_BYTES = 1024 * 1024;
+
+const CHILD_ENV_ALLOWLIST = [
+  'PATH',
+  'Path',
+  'PATHEXT',
+  'SystemRoot',
+  'WINDIR',
+  'COMSPEC',
+  'HOME',
+  'USERPROFILE',
+  'HOMEDRIVE',
+  'HOMEPATH',
+  'APPDATA',
+  'LOCALAPPDATA',
+  'TEMP',
+  'TMP',
+  'LANG',
+  'LC_ALL',
+] as const;
 
 function getSanitizedChildEnv(): NodeJS.ProcessEnv {
-  const env = { ...process.env };
-  delete env.GEMINI_API_KEY;
-  delete env.GOOGLE_API_KEY;
-  delete env.ANTHROPIC_API_KEY;
-  delete env.OPENAI_API_KEY;
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of CHILD_ENV_ALLOWLIST) {
+    if (process.env[key] !== undefined) {
+      env[key] = process.env[key];
+    }
+  }
   return env;
+}
+
+function truncateForLog(value: string, maxBytes = MAX_RAW_RESULT_LOG_BYTES): string {
+  const valueBytes = Buffer.byteLength(value, 'utf-8');
+  if (valueBytes <= maxBytes) return value;
+
+  const truncated = Buffer.from(value, 'utf-8').subarray(0, maxBytes).toString('utf-8');
+  return `${truncated}\n[truncated ${valueBytes - maxBytes} bytes]`;
+}
+
+function countLines(value: string): number {
+  if (value === '') return 0;
+  let count = 1;
+  for (let i = 0; i < value.length; i += 1) {
+    if (value.charCodeAt(i) === 10) count += 1;
+  }
+  return count;
+}
+
+function isLikelyBinary(buffer: Buffer): boolean {
+  return buffer.includes(0);
 }
 
 function isWithinDirectory(basePath: string, targetPath: string): boolean {
@@ -51,21 +99,11 @@ async function resolveExistingFileWithinCwd(inputPath: string): Promise<string> 
   return realPath;
 }
 
-async function resolveOutputFileWithinCwd(inputPath: string): Promise<string> {
-  const cwdReal = await fs.promises.realpath(process.cwd());
+async function resolveOutputFile(inputPath: string): Promise<string> {
   const resolvedPath = path.resolve(process.cwd(), inputPath);
-
-  if (!isWithinDirectory(cwdReal, resolvedPath)) {
-    throw new Error(`Caminho fora do projeto: ${inputPath}`);
-  }
-
   const outputDir = path.dirname(resolvedPath);
   await fs.promises.mkdir(outputDir, { recursive: true });
   const outputDirReal = await fs.promises.realpath(outputDir);
-  if (!isWithinDirectory(cwdReal, outputDirReal)) {
-    throw new Error(`Caminho fora do projeto: ${inputPath}`);
-  }
-
   return path.join(outputDirReal, path.basename(resolvedPath));
 }
 
@@ -119,11 +157,129 @@ async function getGitDiff(): Promise<string> {
   });
 }
 
+async function getUntrackedFilesDiff(): Promise<string> {
+  const output = await new Promise<Buffer>((resolve, reject) => {
+    const proc = spawn('git', ['ls-files', '--others', '--exclude-standard', '-z'], {
+      env: getSanitizedChildEnv(),
+    });
+    const chunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let totalBytes = 0;
+    let totalStderrBytes = 0;
+    let settled = false;
+    const timeout = setTimeout(() => {
+      proc.kill('SIGKILL');
+      finish(() => reject(new Error(`git ls-files excedeu o timeout de ${GIT_DIFF_TIMEOUT_MS / 1000}s.`)));
+    }, GIT_DIFF_TIMEOUT_MS);
+
+    const finish = (fn: () => void) => {
+      if (!settled) { settled = true; clearTimeout(timeout); fn(); }
+    };
+
+    proc.stdout.on('data', (chunk: Buffer) => {
+      totalBytes += chunk.length;
+      if (totalBytes > MAX_UNTRACKED_LIST_BYTES) {
+        proc.kill('SIGKILL');
+        finish(() => reject(new Error('Lista de arquivos untracked excede o limite permitido.')));
+        return;
+      }
+      chunks.push(chunk);
+    });
+
+    proc.stderr.on('data', (chunk: Buffer) => {
+      totalStderrBytes += chunk.length;
+      if (totalStderrBytes <= MAX_STDERR_BYTES) {
+        stderrChunks.push(chunk);
+      }
+    });
+
+    proc.on('close', (code) => {
+      if (code !== 0) {
+        finish(() => reject(new Error(Buffer.concat(stderrChunks).toString('utf-8') || `git ls-files saiu com codigo ${code}`)));
+        return;
+      }
+
+      finish(() => resolve(Buffer.concat(chunks)));
+    });
+    proc.on('error', (err) => finish(() => reject(err)));
+  });
+
+  const files = output.toString('utf-8').split('\0').filter(Boolean).slice(0, MAX_UNTRACKED_FILES);
+  if (files.length === 0) return '';
+
+  const cwdReal = await fs.promises.realpath(process.cwd());
+  const sections: string[] = [];
+  let totalBytes = 0;
+
+  for (const file of files) {
+    const targetPath = path.resolve(process.cwd(), file);
+    let resolvedPath: string;
+    try {
+      resolvedPath = await fs.promises.realpath(targetPath);
+    } catch {
+      continue;
+    }
+
+    if (!isWithinDirectory(cwdReal, resolvedPath) || isBlockedSensitivePath(resolvedPath)) {
+      continue;
+    }
+
+    try {
+      const stat = await fs.promises.stat(resolvedPath);
+      if (!stat.isFile() || stat.size > MAX_UNTRACKED_DIFF_FILE_BYTES) {
+        continue;
+      }
+
+      const buffer = await fs.promises.readFile(resolvedPath);
+      if (isLikelyBinary(buffer)) {
+        continue;
+      }
+
+      const content = buffer.toString('utf-8');
+      const normalizedContent = content.replace(/\r\n/g, '\n').replace(/\n$/, '');
+      const lineCount = countLines(normalizedContent);
+      const addedLines = normalizedContent ? normalizedContent.replace(/^/gm, '+') : '';
+      const section = [
+        `diff --git a/${file} b/${file}`,
+        'new file mode 100644',
+        '--- /dev/null',
+        `+++ b/${file}`,
+        `@@ -0,0 +1,${lineCount} @@`,
+        addedLines,
+        '',
+      ].join('\n');
+
+      totalBytes += Buffer.byteLength(section, 'utf-8');
+      if (totalBytes > MAX_DIFF_BYTES) {
+        throw new Error(`Diff com arquivos untracked excede o limite maximo permitido de ${MAX_DIFF_BYTES / 1024 / 1024}MB.`);
+      }
+      sections.push(section);
+    } catch (error: unknown) {
+      if (error instanceof Error && error.message.startsWith('Diff com arquivos untracked excede')) {
+        throw error;
+      }
+      const message = error instanceof Error ? error.message : 'unknown file error';
+      console.warn(pc.yellow(`[ALEX] Untracked file omitted for ${file}: ${message}`));
+    }
+  }
+
+  return sections.join('');
+}
+
+async function getLocalReviewDiff(): Promise<string> {
+  const [trackedDiff, untrackedDiff] = await Promise.all([
+    getGitDiff(),
+    getUntrackedFilesDiff(),
+  ]);
+  return [trackedDiff, untrackedDiff].filter((part) => part.trim()).join('\n');
+}
+
 async function getChangedFilesContext(diffContent: string): Promise<string | undefined> {
   const metadata = extractCodeMetadata(diffContent);
   const cwdReal = await fs.promises.realpath(process.cwd());
-  let combinedContext = '';
   let totalBytes = 0;
+  let limitReached = false;
+  const selectedFiles: Array<{ file: string; resolvedPath: string }> = [];
 
   const files = metadata.files.slice(0, MAX_CONTEXT_FILES);
   for (const file of files) {
@@ -136,7 +292,7 @@ async function getChangedFilesContext(diffContent: string): Promise<string | und
       continue;
     }
 
-    if (!resolvedPath.startsWith(cwdReal + path.sep) && resolvedPath !== cwdReal) {
+    if (!isWithinDirectory(cwdReal, resolvedPath)) {
       continue;
     }
 
@@ -149,16 +305,40 @@ async function getChangedFilesContext(diffContent: string): Promise<string | und
       continue;
     }
 
-    const content = await fs.promises.readFile(resolvedPath, 'utf-8');
-    const section = `=== File: ${file} ===\n${content}\n`;
-    const sectionBytes = Buffer.byteLength(section, 'utf-8');
+    const sectionOverheadBytes = Buffer.byteLength(`=== File: ${file} ===\n\n`, 'utf-8');
+    const sectionBytes = sectionOverheadBytes + stat.size;
     if (totalBytes + sectionBytes > MAX_CONTEXT_TOTAL_BYTES) {
-      combinedContext += '\n=== CONTEXT NOTICE ===\nFull-file context limit reached; some changed files were omitted.\n';
+      limitReached = true;
       break;
     }
 
-    combinedContext += section;
+    selectedFiles.push({ file, resolvedPath });
     totalBytes += sectionBytes;
+  }
+
+  const sections: string[] = [];
+  const READ_BATCH_SIZE = 8;
+  for (let i = 0; i < selectedFiles.length; i += READ_BATCH_SIZE) {
+    const batch = selectedFiles.slice(i, i + READ_BATCH_SIZE);
+    const batchSections = await Promise.all(
+      batch.map(async ({ file, resolvedPath }) => {
+        try {
+          const content = await fs.promises.readFile(resolvedPath, 'utf-8');
+          return `=== File: ${file} ===\n${content}\n`;
+        } catch (error: unknown) {
+          const message = error instanceof Error ? error.message : 'unknown read error';
+          console.warn(pc.yellow(`[ALEX] Context omitted for ${file}: ${message}`));
+          return `=== File: ${file} ===\n[context omitted: file could not be read: ${message}]\n`;
+        }
+      }),
+    );
+    sections.push(...batchSections);
+  }
+
+  let combinedContext = sections.join('');
+
+  if (limitReached) {
+    combinedContext += '\n=== CONTEXT NOTICE ===\nFull-file context limit reached; some changed files were omitted.\n';
   }
 
   if (metadata.files.length > MAX_CONTEXT_FILES) {
@@ -198,17 +378,65 @@ async function runAnalysis(request: {
   metadata: { stack: string; project: string };
   diff?: string;
   sourceCode?: string;
-}, model: string): Promise<FinalReport> {
-  const orchestrator = new ReviewOrchestrator(model);
+}, model: string, enabledAgents?: AgentId[]): Promise<FinalReport> {
+  const orchestrator = new ReviewOrchestrator(model, { enabledAgents });
   const rawResult = await orchestrator.analyze(request);
-  const parsed = extractAndParseJSON(rawResult);
-  const validation = FinalReportSchema.safeParse(parsed);
+  let parsed: unknown;
 
+  try {
+    parsed = extractAndParseJSON(rawResult);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'JSON invalido.';
+    throw new LlmResultParseError(message, rawResult);
+  }
+
+  const validation = FinalReportSchema.safeParse(parsed);
   if (!validation.success) {
-    throw new Error(`Contrato de resposta invalido: ${validation.error.message}`);
+    throw new LlmResultParseError(
+      `Contrato de resposta invalido: ${validation.error.message}`,
+      rawResult,
+    );
   }
 
   return validation.data;
+}
+
+/**
+ * Resolve o conjunto final de agentes com a precedência correta: CLI > env vars.
+ * Erros de validação (ID inválido, council vazio) são relançados para o chamador.
+ */
+function resolveAgents(cliAgents?: string, cliDisabled?: string): AgentId[] {
+  const agents = cliAgents !== undefined ? cliAgents : process.env.ALEX_AGENTS;
+  const disabled = cliDisabled !== undefined ? cliDisabled : process.env.ALEX_DISABLED_AGENTS;
+  return resolveAgentIds({ agents, disabledAgents: disabled });
+}
+
+function resolveAgentsOrExit(cliAgents?: string, cliDisabled?: string): AgentId[] {
+  try {
+    return resolveAgents(cliAgents, cliDisabled);
+  } catch (error: unknown) {
+    console.error(pc.red(error instanceof Error ? error.message : 'Selecao de agentes invalida.'));
+    process.exit(1);
+  }
+}
+
+function failAnalysis(spinner: ReturnType<typeof ora>, error: unknown): never {
+  if (error instanceof LlmResultParseError) {
+    spinner.fail(pc.red('Erro ao interpretar a resposta da IA. O formato JSON esperado falhou.'));
+    console.error(pc.red(error.message));
+    console.error(truncateForLog(error.rawResult));
+    process.exit(1);
+  }
+
+  spinner.fail(pc.red('Erro durante a analise do A.L.E.X.'));
+  if (error instanceof Error) {
+    if (error.message && error.message.includes('429')) {
+      console.error(pc.yellow('\nLimite de Cota Atingido (429 Too Many Requests). Verifique sua chave de API ou aguarde alguns minutos.\n'));
+    } else {
+      console.error(pc.red(error.message));
+    }
+  }
+  process.exit(1);
 }
 
 async function writeReportFile(filePath: string, content: string): Promise<void> {
@@ -345,6 +573,36 @@ configCommand
   });
 
 configCommand
+  .command('set-agents <agents>')
+  .description('Define o perfil persistente de agentes. Ex: default,test-strategist.')
+  .action((agents) => {
+    try {
+      resolveAgentIds({ agents });
+    } catch (error: unknown) {
+      console.error(pc.red(error instanceof Error ? error.message : 'Selecao de agentes invalida.'));
+      process.exit(1);
+    }
+
+    updateUserConfig({ agents });
+    console.log(pc.green(`Perfil de agentes salvo: ${agents}`));
+  });
+
+configCommand
+  .command('disable-agent <agents>')
+  .description('Define agentes persistentes a desabilitar. Ex: docs-maintainer.')
+  .action((agents) => {
+    try {
+      resolveAgentIds({ disabledAgents: agents });
+    } catch (error: unknown) {
+      console.error(pc.red(error instanceof Error ? error.message : 'Selecao de agentes invalida.'));
+      process.exit(1);
+    }
+
+    updateUserConfig({ disabledAgents: agents });
+    console.log(pc.green(`Agentes desabilitados salvos: ${agents}`));
+  });
+
+configCommand
   .command('show')
   .description('Mostra a configuração ativa sem exibir segredos.')
   .action(() => {
@@ -357,22 +615,28 @@ configCommand
     console.log(`Config path: ${getConfigPath()}`);
     console.log(`GEMINI_API_KEY: ${hasKey ? `configured (${keySource})` : 'missing'}`);
     console.log(`ALEX_MODEL: ${activeModel} (${modelSource})`);
+    console.log(`ALEX_AGENTS: ${process.env.ALEX_AGENTS || userConfig.agents || 'default'}`);
+    console.log(`ALEX_DISABLED_AGENTS: ${process.env.ALEX_DISABLED_AGENTS || userConfig.disabledAgents || '(none)'}`);
   });
 
 program
-  .command('review')
+  .command('review [profile]')
   .description('Analisa as modificações locais (git diff) usando o conselho de especialistas.')
   .option('-m, --model <modelo>', 'Modelo LLM para utilizar na análise', defaultModel)
-  .action(async (options) => {
+  .option('--agents <lista>', 'Agentes habilitados (vírgula). Ex: security-auditor,clean-coder. Usa env ALEX_AGENTS se omitido.')
+  .option('--disable-agents <lista>', 'Agentes a remover do conjunto. Ex: sre-agent. Usa env ALEX_DISABLED_AGENTS se omitido.')
+  .action(async (profile, options) => {
     ensureGeminiApiKey();
     console.log(pc.cyan(pc.bold('\n🛡️ A.L.E.X Code Review Iniciado\n')));
+
+    const enabledAgents = resolveAgentsOrExit(options.agents ?? profile, options.disableAgents);
 
     const spinner = ora('Capturando git diff local...').start();
 
     let diffContent = '';
     try {
       // Usa spawn com limite de bytes para evitar DoS/OOM em repositórios grandes
-      diffContent = await getGitDiff();
+      diffContent = await getLocalReviewDiff();
     } catch (error: unknown) {
       spinner.fail(pc.red('Falha ao tentar executar git diff. Certifique-se de que está em um repositório git.'));
       if (error instanceof Error) {
@@ -389,7 +653,6 @@ program
     const modelToUse = options.model || defaultModel;
     spinner.text = `Analisando código com o Conselho de Especialistas (${modelToUse})... Isso pode levar alguns segundos.`;
 
-    const orchestrator = new ReviewOrchestrator(modelToUse);
     
     const request = {
       metadata: {
@@ -401,37 +664,13 @@ program
     };
 
     try {
-      const rawResult = await orchestrator.analyze(request);
-      
-      let result: FinalReport;
-      try {
-        const parsed = extractAndParseJSON(rawResult);
-        const validation = FinalReportSchema.safeParse(parsed);
-        if (!validation.success) {
-          throw new Error(`Contrato de resposta inválido: ${validation.error.message}`);
-        }
-        result = validation.data;
-      } catch (parseError) {
-        spinner.fail(pc.red('Erro ao interpretar a resposta da IA. O formato JSON esperado falhou.'));
-        console.error(rawResult);
-        process.exit(1);
-      }
+      const result = await runAnalysis(request, modelToUse, enabledAgents);
 
       printVerdict(spinner, result);
       if (result.verdict !== 'PASS') process.exit(1);
       
     } catch (error: unknown) {
-      spinner.fail(pc.red('Erro durante a análise do A.L.E.X.'));
-      
-      if (error instanceof Error) {
-        if (error.message && error.message.includes('429')) {
-           console.error(pc.yellow('\n⚠️ Limite de Cota Atingido (429 Too Many Requests). Verifique sua chave de API ou aguarde alguns minutos.\n'));
-        } else {
-           // Loga apenas a mensagem para não vazar a GEMINI_API_KEY embutida no objeto Error
-           console.error(pc.red(error.message));
-        }
-      }
-      process.exit(1);
+      failAnalysis(spinner, error);
     }
   });
 
@@ -439,9 +678,13 @@ program
   .command('analyze <caminho>')
   .description('Analisa um arquivo de código completo estruturalmente.')
   .option('-m, --model <modelo>', 'Modelo LLM para utilizar na análise', defaultModel)
+  .option('--agents <lista>', 'Agentes habilitados (vírgula). Ex: security-auditor,clean-coder. Usa env ALEX_AGENTS se omitido.')
+  .option('--disable-agents <lista>', 'Agentes a remover do conjunto. Ex: sre-agent. Usa env ALEX_DISABLED_AGENTS se omitido.')
   .action(async (caminho, options) => {
     ensureGeminiApiKey();
     console.log(pc.cyan(pc.bold('\n🛡️ A.L.E.X Code Analysis Iniciado\n')));
+
+    const enabledAgents = resolveAgentsOrExit(options.agents, options.disableAgents);
 
     const targetPath = path.resolve(process.cwd(), caminho);
     
@@ -454,7 +697,7 @@ program
       process.exit(1);
     }
     const cwdReal = await fs.promises.realpath(process.cwd());
-    if (!resolvedPath!.startsWith(cwdReal + path.sep) && resolvedPath! !== cwdReal) {
+    if (!isWithinDirectory(cwdReal, resolvedPath!)) {
       console.error(pc.red(`Erro de Segurança: O caminho está fora do escopo do projeto (${resolvedPath!}).`));
       process.exit(1);
     }
@@ -503,7 +746,6 @@ program
     const modelToUse = options.model || defaultModel;
     spinner.text = `Analisando arquivo com o Conselho de Especialistas (${modelToUse})... Isso pode levar alguns segundos.`;
 
-    const orchestrator = new ReviewOrchestrator(modelToUse);
     
     const request = {
       metadata: {
@@ -514,36 +756,13 @@ program
     };
 
     try {
-      const rawResult = await orchestrator.analyze(request);
-      
-      let result: FinalReport;
-      try {
-        const parsed = extractAndParseJSON(rawResult);
-        const validation = FinalReportSchema.safeParse(parsed);
-        if (!validation.success) {
-          throw new Error(`Contrato de resposta inválido: ${validation.error.message}`);
-        }
-        result = validation.data;
-      } catch (parseError) {
-        spinner.fail(pc.red('Erro ao interpretar a resposta da IA. O formato JSON esperado falhou.'));
-        console.error(rawResult);
-        process.exit(1);
-      }
+      const result = await runAnalysis(request, modelToUse, enabledAgents);
 
       printVerdict(spinner, result);
       if (result.verdict !== 'PASS') process.exit(1);
       
     } catch (error: unknown) {
-      spinner.fail(pc.red('Erro durante a análise do A.L.E.X.'));
-      if (error instanceof Error) {
-        if (error.message && error.message.includes('429')) {
-           console.error(pc.yellow('\n⚠️ Limite de Cota Atingido (429 Too Many Requests). Verifique sua chave de API ou aguarde alguns minutos.\n'));
-        } else {
-           // Loga apenas a mensagem para não vazar a GEMINI_API_KEY embutida no objeto Error
-           console.error(pc.red(error.message));
-        }
-      }
-      process.exit(1);
+      failAnalysis(spinner, error);
     }
   });
 
@@ -557,13 +776,17 @@ program
   .option('--pr-number <numero>', 'Numero do PR para enriquecer o titulo.')
   .option('-m, --model <modelo>', 'Modelo LLM para utilizar na analise', defaultModel)
   .option('--fail-on-fail', 'Retorna exit code 1 quando o veredito for FAIL.')
+  .option('--agents <lista>', 'Agentes habilitados (vírgula). Ex: security-auditor,clean-coder. Usa env ALEX_AGENTS se omitido.')
+  .option('--disable-agents <lista>', 'Agentes a remover do conjunto. Ex: docs-maintainer. Usa env ALEX_DISABLED_AGENTS se omitido.')
   .action(async (options) => {
     ensureGeminiApiKey();
     const modelToUse = options.model || defaultModel;
 
+    const enabledAgents = resolveAgentsOrExit(options.agents, options.disableAgents);
+
     try {
       const diffPath = await resolveExistingFileWithinCwd(options.diffFile);
-      const outputPath = await resolveOutputFileWithinCwd(options.outputFile);
+      const outputPath = await resolveOutputFile(options.outputFile);
       const stat = await fs.promises.stat(diffPath);
       if (!stat.isFile() || stat.size > MAX_DIFF_BYTES) {
         throw new Error(`Arquivo de diff invalido ou maior que ${MAX_DIFF_BYTES / 1024 / 1024}MB.`);
@@ -583,7 +806,7 @@ program
         sourceCode: sanitizeDiff(await getChangedFilesContext(diffContent) || ''),
       };
 
-      const result = await runAnalysis(request, modelToUse);
+      const result = await runAnalysis(request, modelToUse, enabledAgents);
       const title = options.prNumber ? `A.L.E.X Code Review - PR #${options.prNumber}` : 'A.L.E.X Code Review';
       const output = options.format === 'json'
         ? JSON.stringify(result, null, 2)
@@ -597,6 +820,12 @@ program
         process.exit(1);
       }
     } catch (error: unknown) {
+      if (error instanceof LlmResultParseError) {
+        console.error(pc.red(error.message));
+        console.error(truncateForLog(error.rawResult));
+        process.exit(1);
+      }
+
       console.error(pc.red(error instanceof Error ? error.message : 'Falha inesperada no modo CI.'));
       process.exit(1);
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,11 +8,15 @@ export const FALLBACK_MODEL = 'gemini-2.5-pro';
 const UserConfigSchema = z.object({
   geminiApiKey: z.string().optional(),
   model: z.string().optional(),
+  agents: z.string().optional(),
+  disabledAgents: z.string().optional(),
 });
 
 export type AlexUserConfig = {
   geminiApiKey?: string;
   model?: string;
+  agents?: string;
+  disabledAgents?: string;
 };
 
 let cachedUserConfig: AlexUserConfig | undefined;
@@ -26,13 +30,26 @@ export function readUserConfig(): AlexUserConfig {
 
   try {
     const raw = fs.readFileSync(getConfigPath(), 'utf-8');
-    const validation = UserConfigSchema.safeParse(JSON.parse(raw));
-    cachedUserConfig = validation.success ? validation.data : {};
+    const parsed = JSON.parse(raw);
+    const validation = UserConfigSchema.safeParse(parsed);
+    if (!validation.success) {
+      console.warn(`Config invalid at ${getConfigPath()}; ignoring stored values.`);
+      cachedUserConfig = {};
+      return cachedUserConfig;
+    }
+
+    cachedUserConfig = validation.data;
     return cachedUserConfig;
   } catch (error: unknown) {
     if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
       cachedUserConfig = {};
       return {};
+    }
+
+    if (error instanceof SyntaxError) {
+      console.warn(`Config JSON invalid at ${getConfigPath()}; ignoring stored values.`);
+      cachedUserConfig = {};
+      return cachedUserConfig;
     }
 
     throw error;
@@ -53,12 +70,31 @@ export function writeUserConfig(config: AlexUserConfig): void {
     }
   }
 
-  const flags = fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC | fs.constants.O_NOFOLLOW;
-  const fd = fs.openSync(configPath, flags, 0o600);
+  const tempPath = path.join(configDir, `.config.${process.pid}.${Date.now()}.tmp`);
+  const flags = fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL;
+  const fd = fs.openSync(tempPath, flags, 0o600);
   try {
     fs.writeFileSync(fd, `${JSON.stringify(config, null, 2)}\n`, { encoding: 'utf-8' });
-  } finally {
     fs.closeSync(fd);
+    fs.renameSync(tempPath, configPath);
+  } catch (error: unknown) {
+    try {
+      fs.closeSync(fd);
+    } catch {
+      // Already closed.
+    }
+    try {
+      fs.rmSync(tempPath, { force: true });
+    } catch {
+      // Best effort cleanup.
+    }
+    throw error;
+  } finally {
+    try {
+      fs.rmSync(tempPath, { force: true });
+    } catch {
+      // Best effort cleanup.
+    }
   }
   cachedUserConfig = config;
 
@@ -89,10 +125,16 @@ export function getDefaultModel(): string {
 
 export function applyStoredConfigToEnv(): void {
   const config = readUserConfig();
-  if (!process.env.GEMINI_API_KEY && config.geminiApiKey) {
+  if (process.env.GEMINI_API_KEY === undefined && config.geminiApiKey) {
     process.env.GEMINI_API_KEY = config.geminiApiKey;
   }
-  if (!process.env.ALEX_MODEL && config.model) {
+  if (process.env.ALEX_MODEL === undefined && config.model) {
     process.env.ALEX_MODEL = config.model;
+  }
+  if (process.env.ALEX_AGENTS === undefined && config.agents) {
+    process.env.ALEX_AGENTS = config.agents;
+  }
+  if (process.env.ALEX_DISABLED_AGENTS === undefined && config.disabledAgents) {
+    process.env.ALEX_DISABLED_AGENTS = config.disabledAgents;
   }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,9 @@
+export class LlmResultParseError extends Error {
+  constructor(
+    message: string,
+    readonly rawResult: string,
+  ) {
+    super(message);
+    this.name = 'LlmResultParseError';
+  }
+}

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,6 +1,8 @@
 import { InMemoryRunner, stringifyContent } from '@google/adk';
 import crypto from 'crypto';
-import { createRootAgent } from './agent.js';
+import { createRootAgent, CreateRootAgentOpts } from './agent.js';
+import { AgentId, DEFAULT_AGENT_IDS } from './agents/catalog.js';
+import { getPipelineRetryConfig, getRetryDelayMs, isTransientAgentError, sleepForRetry } from './agents/retry_policy.js';
 import { AnalysisPayload } from './schemas/contracts.js';
 import { extractCodeMetadata } from './tools/diff_tools.js';
 
@@ -8,14 +10,23 @@ import { extractCodeMetadata } from './tools/diff_tools.js';
  * ReviewOrchestrator - Fachada para o sistema A.L.E.X
  * Encapsula a complexidade do Runner e Session do ADK.
  */
+export interface ReviewOrchestratorOpts {
+  /** IDs dos agentes a incluir no pipeline (omitir = comportamento padrão). */
+  enabledAgents?: AgentId[];
+}
+
 export class ReviewOrchestrator {
   private runner: InMemoryRunner;
   private appName = 'ALEX-Core';
+  private activeAgentCount: number;
 
-  constructor(model?: string) {
-    // No ADK TS, o construtor recebe um objeto
+  constructor(model?: string, opts: ReviewOrchestratorOpts = {}) {
+    const agentOpts: CreateRootAgentOpts = {
+      enabledAgents: opts.enabledAgents,
+    };
+    this.activeAgentCount = opts.enabledAgents?.length ?? DEFAULT_AGENT_IDS.length;
     this.runner = new InMemoryRunner({
-      agent: createRootAgent(model),
+      agent: createRootAgent(model, agentOpts),
       appName: this.appName
     });
   }
@@ -31,22 +42,40 @@ export class ReviewOrchestrator {
       ...input,
       streamId: input.streamId || crypto.randomUUID(),
       metadata: {
+        ...input.metadata,
         stack: codeMetadata.detectedStack,
         project: input.metadata?.project || 'local-workspace',
-        model: input.metadata?.model,
         filesAffected: codeMetadata.filesCount,
       },
     };
     
-    // 1. Criar uma sessão
+    console.log(`[ALEX] Iniciando análise da transação: ${normalizedInput.streamId}`);
+
+    const { maxRetries, baseDelayMs } = getPipelineRetryConfig(this.activeAgentCount);
+
+    for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+      try {
+        return await this.runPipelineOnce(userId, normalizedInput);
+      } catch (error: unknown) {
+        if (!isRetryablePipelineError(error) || attempt >= maxRetries) {
+          throw error;
+        }
+
+        const delayMs = getRetryDelayMs(attempt + 1, baseDelayMs);
+        console.warn(`[ALEX] Falha transitória no pipeline ${normalizedInput.streamId}; retry ${attempt + 1}/${maxRetries} em ${delayMs}ms. ${getErrorMessage(error)}`);
+        await sleepForRetry(delayMs);
+      }
+    }
+
+    throw new Error('O pipeline terminou sem gerar conteúdo.');
+  }
+
+  private async runPipelineOnce(userId: string, normalizedInput: AnalysisPayload): Promise<string> {
     const session = await this.runner.sessionService.createSession({
       appName: this.appName,
       userId: userId
     });
 
-    console.log(`[ALEX] Iniciando análise da transação: ${normalizedInput.streamId}`);
-
-    // 2. Executar o pipeline
     const eventStream = this.runner.runAsync({
       userId: userId,
       sessionId: session.id,
@@ -56,30 +85,45 @@ export class ReviewOrchestrator {
       }
     });
 
-    // 3. Capturar resultados
     let lastContent: string | null = null;
 
     for await (const event of eventStream) {
-      // Debug
-      // console.log('--- EVENT ---', JSON.stringify(event, null, 2));
-      
       if (event.errorCode) {
-        throw new Error(`[ADK Error] Author: ${event.author} | Code: ${event.errorCode} | Msg: ${event.errorMessage}`);
+        throw new AdkPipelineError(event.author, event.errorCode, event.errorMessage);
       }
 
       const content = stringifyContent(event);
-      if (content) {
-        lastContent = content;
-        // Ocultando console log poluidor de debug se não for final
-        // console.log(`[${event.author}] ... ${content.substring(0, 50).replace(/\n/g, ' ')}...`);
-      }
+      if (content) lastContent = content;
     }
 
     if (lastContent) {
-      console.log(`[ALEX] Análise finalizada com sucesso.`);
+      console.log(`[ALEX] Análise finalizada com sucesso. streamId=${normalizedInput.streamId}`);
       return lastContent;
     }
 
     throw new Error('O pipeline terminou sem gerar conteúdo.');
   }
+}
+
+export class AdkPipelineError extends Error {
+  constructor(
+    readonly author: string | undefined,
+    readonly errorCode: string,
+    readonly errorMessage: string | undefined,
+  ) {
+    super(`[ADK Error] Author: ${author} | Code: ${errorCode} | Msg: ${errorMessage}`);
+    this.name = 'AdkPipelineError';
+  }
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function isRetryablePipelineError(error: unknown): boolean {
+  if (error instanceof AdkPipelineError) {
+    return isTransientAgentError(error.errorCode, error.errorMessage);
+  }
+
+  return error instanceof Error && isTransientAgentError(undefined, error.message);
 }

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -22,6 +22,26 @@ export const BUSINESS_PROXY_PROMPT = `Você é o "Business Proxy". Sua responsab
 IMPORTANTE: Sempre utilize a ferramenta "search_local_rules" antes de dar seu veredito, para ler as documentações e garantir aderência às regras corporativas.
 ${EVIDENCE_RULES}`;
 
+export const ERROR_HANDLING_SPECIALIST_PROMPT = `Voce e o "Error Handling Specialist". Sua responsabilidade e avaliar caminhos de erro, fail-open/fail-closed, retries, rollback, idempotencia, mascaramento de segredos e propagacao de excecoes.
+Procure erros silenciosos, mensagens inseguras ou pouco acionaveis, tratamento inconsistente de falhas externas e estados parcialmente aplicados.
+${EVIDENCE_RULES}`;
+
+export const TEST_STRATEGIST_PROMPT = `Voce e o "Test Strategist". Sua responsabilidade e avaliar cobertura, regressao, casos negativos, isolamento, mocks, fixtures, testes frageis e gaps de CI.
+Priorize riscos que podem escapar para producao por falta de verificacao automatizada ou por testes que validam comportamento errado.
+${EVIDENCE_RULES}`;
+
+export const OBSERVABILITY_ENGINEER_PROMPT = `Voce e o "Observability Engineer". Sua responsabilidade e avaliar logs, metricas, traces, correlation IDs, alertas, auditabilidade e debuggability.
+Procure operacoes criticas sem sinais suficientes para diagnostico, incident response ou auditoria, respeitando privacidade e segredos.
+${EVIDENCE_RULES}`;
+
+export const DOCS_MAINTAINER_PROMPT = `Voce e o "Docs Maintainer". Sua responsabilidade e avaliar se README, changelog, exemplos, docs de API, runbooks ou docs operacionais precisam mudar junto com o codigo.
+Emita achados apenas quando a mudanca de comportamento, contrato, instalacao, configuracao ou operacao exigir documentacao.
+${EVIDENCE_RULES}`;
+
+export const SCALABILITY_ARCHITECT_PROMPT = `Voce e o "Scalability Architect". Sua responsabilidade e avaliar throughput, concorrencia, filas, cache, backpressure, crescimento de dados e arquitetura multi-instancia.
+Procure gargalos de escala, estado local indevido, ausencia de limites e suposicoes que falham com volume ou paralelismo.
+${EVIDENCE_RULES}`;
+
 export const SECURITY_REVIEWER_PROMPT = `Analise os achados anteriores de PERFORMANCE e QUALIDADE presentes no histórico da sessão.
 Verifique se alguma otimização introduz brechas de segurança. Levante vetos se necessário.
 ${EVIDENCE_RULES}
@@ -30,6 +50,22 @@ ${EVIDENCE_RULES}
 - Performance: {performance_findings?}
 - Qualidade: {quality_findings?}
 `;
+
+export function buildArchitectConsolidatorInstruction(
+  councilSection: string,
+  reflectionSection: string,
+): string {
+  return `Voce e o "Architect". Sua missao e consolidar o relatorio final em JSON estrito.
+Analise os achados iniciais e as criticas da fase de reflexao injetados abaixo.
+Resolva conflitos e emita o veredito (PASS, FAIL, WARN). Se houver apontamentos com severidade Blocker, o veredito deve ser FAIL.
+
+**Resultados do Conselho Paralelo:**
+${councilSection}
+
+**Resultados da Reflexao (Criticas):**
+${reflectionSection}
+`;
+}
 
 export const PERFORMANCE_REVIEWER_PROMPT = `Analise os achados anteriores de SEGURANÇA e QUALIDADE presentes no histórico da sessão.
 Verifique se as correções causam gargalos de performance.

--- a/src/schemas/contracts.ts
+++ b/src/schemas/contracts.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod';
 
 export const MAX_ANALYSIS_CONTENT_LENGTH = 10 * 1024 * 1024;
+export const MAX_AGENT_PROFILE_ITEMS = 32;
+export const MAX_AGENT_PROFILE_ITEM_LENGTH = 100;
+const AgentProfileItemSchema = z.string().max(MAX_AGENT_PROFILE_ITEM_LENGTH);
 
 /**
  * Severidade dos apontamentos seguindo a regra 4 do workspace.
@@ -26,9 +29,11 @@ export const AnalysisIssueSchema = z.object({
 export const AnalysisPayloadSchema = z.object({
   streamId: z.string().uuid().optional().describe('ID único da transação de análise. Quando ausente, a API gera um UUID.'),
   metadata: z.object({
-    stack: z.string().describe('Stack tecnológica (ex: .net, react, node).'),
-    project: z.string().describe('Nome do projeto ou micro-serviço.'),
+    stack: z.string().optional().describe('Stack tecnológica (ex: .net, react, node).'),
+    project: z.string().optional().describe('Nome do projeto ou micro-serviço.'),
     model: z.string().optional().describe('Modelo LLM opcional para esta requisição.'),
+    agents: z.array(AgentProfileItemSchema).max(MAX_AGENT_PROFILE_ITEMS).optional().describe('IDs de agentes habilitados para esta requisicao.'),
+    disabledAgents: z.array(AgentProfileItemSchema).max(MAX_AGENT_PROFILE_ITEMS).optional().describe('IDs de agentes removidos do conjunto final para esta requisicao.'),
     filesAffected: z.number().optional().describe('Número de arquivos afetados, preenchido pelo orquestrador.'),
   }).optional().describe('Metadados do projeto. Quando ausente, a API usa valores padrão.'),
   diff: z.string().max(MAX_ANALYSIS_CONTENT_LENGTH).optional().describe('Conteúdo do diff do Git a ser analisado.'),

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,11 +6,16 @@ import crypto from 'crypto';
 import { createHash } from 'crypto';
 import rateLimit from 'express-rate-limit';
 import { extractAndParseJSON } from './utils/parser.js';
-import { AnalysisPayloadSchema } from './schemas/contracts.js';
+import { AnalysisPayloadSchema, FinalReportSchema } from './schemas/contracts.js';
 import { getDefaultModel } from './config.js';
+import { resolveAgentIds } from './agents/agent_parser.js';
+import { AgentId } from './agents/catalog.js';
+import { LlmResultParseError } from './errors.js';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+const MAX_CONCURRENT_ANALYSES = readPositiveInteger(process.env.ALEX_API_MAX_CONCURRENT_ANALYSES, 2);
+let activeAnalyses = 0;
 
 // trust proxy restrito ao loopback: aceita X-Forwarded-For apenas de proxies na mesma máquina.
 // Para Cloud Run/Kubernetes, substitua 'loopback' pelo CIDR da sua rede interna (ex: '10.0.0.0/8')
@@ -20,6 +25,22 @@ app.set('trust proxy', TRUSTED_PROXY);
 
 app.use(cors());
 const jsonParser = express.json({ limit: '10mb' });
+
+function readPositiveInteger(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+async function withAnalysisSlot<T>(fn: () => Promise<T>): Promise<T | undefined> {
+  if (activeAnalyses >= MAX_CONCURRENT_ANALYSES) return undefined;
+  activeAnalyses += 1;
+  try {
+    return await fn();
+  } finally {
+    activeAnalyses -= 1;
+  }
+}
 
 // Rota de Health-Check (Obrigatório para Cloud Run e Kubernetes)
 app.get('/health', (req, res) => {
@@ -31,6 +52,7 @@ const authMiddleware = (req: express.Request, res: express.Response, next: expre
   const token = process.env.API_BEARER_TOKEN;
   // Fail-Closed: se o token não foi configurado, a API é bloqueada por segurança
   if (!token) {
+    console.error('[API Auth Misconfigured]', { path: req.path });
     return res.status(500).json({ error: "Server Misconfiguration", message: "API_BEARER_TOKEN não está configurado no servidor. Acesso bloqueado." });
   }
 
@@ -42,6 +64,7 @@ const authMiddleware = (req: express.Request, res: express.Response, next: expre
   const isValid = crypto.timingSafeEqual(providedHash, expectedHash);
 
   if (!isValid) {
+    console.warn('[API Unauthorized]', { path: req.path, ip: req.ip });
     return res.status(401).json({ error: "Unauthorized", message: "Token de acesso inválido ou ausente." });
   }
   next();
@@ -60,31 +83,90 @@ const apiLimiter = rateLimit({
 
 // Endpoint principal de Ingestão de Diffs e Arquivos
 app.post('/v1/analyze', apiLimiter, authMiddleware, jsonParser, async (req, res) => {
+  const requestStreamId = typeof req.body?.streamId === 'string' && req.body.streamId.length <= 100 && req.body.streamId !== ''
+    ? req.body.streamId
+    : crypto.randomUUID();
+
   // Valida o payload de entrada via Zod (Contract-First)
   const validation = AnalysisPayloadSchema.safeParse(req.body);
   if (!validation.success) {
+    console.warn('[API Invalid Payload]', {
+      streamId: requestStreamId,
+      details: validation.error.flatten(),
+    });
     return res.status(400).json({ error: "Invalid Payload", details: validation.error.flatten() });
   }
   const { streamId, metadata, diff, sourceCode } = validation.data;
+  const effectiveStreamId = streamId || requestStreamId;
+  let enabledAgents: AgentId[];
+
+  try {
+    enabledAgents = resolveAgentIds({
+      agents: metadata?.agents?.join(','),
+      disabledAgents: metadata?.disabledAgents?.join(','),
+    });
+  } catch (error: unknown) {
+    console.warn('[API Invalid Agent Selection]', {
+      streamId: effectiveStreamId,
+      message: error instanceof Error ? error.message : 'Selecao de agentes invalida.',
+    });
+    return res.status(400).json({
+      error: "Invalid Agent Selection",
+      message: error instanceof Error ? error.message : "Selecao de agentes invalida.",
+    });
+  }
 
   const request = {
-    streamId,
+    streamId: effectiveStreamId,
     metadata: metadata || { stack: "Auto-detected", project: "api-client" },
     diff,
     sourceCode
   };
 
   try {
-    const requestedModel = request.metadata?.model || getDefaultModel();
-    const orchestrator = new ReviewOrchestrator(requestedModel);
-    const rawResult = await orchestrator.analyze(request);
+    const rawResult = await withAnalysisSlot(async () => {
+      const requestedModel = request.metadata?.model || getDefaultModel();
+      const orchestrator = new ReviewOrchestrator(requestedModel, { enabledAgents });
+      return orchestrator.analyze(request);
+    });
+    if (rawResult === undefined) {
+      console.warn('[API Backpressure]', {
+        streamId: effectiveStreamId,
+        activeAnalyses,
+        maxConcurrentAnalyses: MAX_CONCURRENT_ANALYSES,
+      });
+      res.setHeader('Retry-After', '30');
+      return res.status(503).json({
+        error: "Service Unavailable",
+        message: "A.L.E.X esta processando o limite maximo de analises simultaneas. Tente novamente em instantes.",
+      });
+    }
     
     // Parse the JSON result from the Orchestrator
-    const jsonResult = extractAndParseJSON(rawResult);
+    let jsonResult;
+    try {
+      jsonResult = extractAndParseJSON(rawResult);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Falha ao interpretar JSON da IA.';
+      throw new LlmResultParseError(message, rawResult);
+    }
+
+    const reportValidation = FinalReportSchema.safeParse(jsonResult);
+    if (!reportValidation.success) {
+      throw new LlmResultParseError(
+        `Contrato de resposta invalido: ${reportValidation.error.message}`,
+        rawResult,
+      );
+    }
     
-    return res.status(200).json(jsonResult);
+    return res.status(200).json(reportValidation.data);
   } catch (error: unknown) {
-    console.error('[API Error]', error instanceof Error ? error.message : 'Unknown error');
+    console.error('[API Error]', {
+      streamId: effectiveStreamId,
+      message: error instanceof Error ? error.message : 'Unknown error',
+      stack: error instanceof Error ? error.stack : undefined,
+      rawResult: error instanceof LlmResultParseError ? error.rawResult.slice(0, 16_384) : undefined,
+    });
     
     if (error instanceof Error) {
       // Tratar erro de Cota Excedida do Gemini

--- a/tests/evaluation/business-proxy.test.json
+++ b/tests/evaluation/business-proxy.test.json
@@ -1,0 +1,11 @@
+{
+  "id": "business-proxy",
+  "purpose": "Verify that business-rule findings align implementation with declared project contracts.",
+  "cases": [
+    {
+      "name": "detects contract drift",
+      "input": "A prompt is hard-coded after the project requires externalized skills.",
+      "expected": ["contract-first", "configuration boundary"]
+    }
+  ]
+}

--- a/tests/evaluation/clean-coder.test.json
+++ b/tests/evaluation/clean-coder.test.json
@@ -1,0 +1,11 @@
+{
+  "id": "clean-coder",
+  "purpose": "Verify that maintainability findings identify duplicated orchestration and unclear boundaries.",
+  "cases": [
+    {
+      "name": "detects duplicated parsing flow",
+      "input": "Two CLI commands duplicate the same parse and validation block.",
+      "expected": ["duplication", "centralized helper"]
+    }
+  ]
+}

--- a/tests/evaluation/docs-maintainer.test.json
+++ b/tests/evaluation/docs-maintainer.test.json
@@ -1,0 +1,11 @@
+{
+  "id": "docs-maintainer",
+  "purpose": "Verify that documentation findings cover user-facing commands and configuration surfaces.",
+  "cases": [
+    {
+      "name": "detects undocumented agent env vars",
+      "input": "The CLI supports ALEX_AGENTS but README omits it.",
+      "expected": ["README update", "configuration reference"]
+    }
+  ]
+}

--- a/tests/evaluation/error-handling-specialist.test.json
+++ b/tests/evaluation/error-handling-specialist.test.json
@@ -1,0 +1,11 @@
+{
+  "id": "error-handling-specialist",
+  "purpose": "Verify that error-handling findings cover corrupted inputs and recoverable startup failures.",
+  "cases": [
+    {
+      "name": "detects corrupted config crash",
+      "input": "The CLI reads a JSON config file and throws on malformed JSON during startup.",
+      "expected": ["graceful fallback", "diagnostic warning"]
+    }
+  ]
+}

--- a/tests/evaluation/observability-engineer.test.json
+++ b/tests/evaluation/observability-engineer.test.json
@@ -1,0 +1,11 @@
+{
+  "id": "observability-engineer",
+  "purpose": "Verify that observability findings improve debuggability without leaking secrets.",
+  "cases": [
+    {
+      "name": "detects missing auth failure logs",
+      "input": "An API returns 401 without structured warning logs.",
+      "expected": ["structured log", "no token leakage"]
+    }
+  ]
+}

--- a/tests/evaluation/performance-reviewer.test.json
+++ b/tests/evaluation/performance-reviewer.test.json
@@ -1,0 +1,11 @@
+{
+  "id": "performance-reviewer",
+  "purpose": "Verify that the reviewer critiques other agents through a performance lens.",
+  "cases": [
+    {
+      "name": "reviews security advice for latency impact",
+      "input": "A security suggestion adds serial filesystem reads for every changed file.",
+      "expected": ["latency tradeoff", "bounded batching"]
+    }
+  ]
+}

--- a/tests/evaluation/scalability-architect.test.json
+++ b/tests/evaluation/scalability-architect.test.json
@@ -1,0 +1,11 @@
+{
+  "id": "scalability-architect",
+  "purpose": "Verify that scalability findings cover concurrency, batching, and memory pressure.",
+  "cases": [
+    {
+      "name": "detects unsafe concurrent reads",
+      "input": "A context builder reads many files concurrently before enforcing total size limits.",
+      "expected": ["preflight limits", "bounded concurrency"]
+    }
+  ]
+}

--- a/tests/evaluation/security-auditor.test.json
+++ b/tests/evaluation/security-auditor.test.json
@@ -1,0 +1,11 @@
+{
+  "id": "security-auditor",
+  "purpose": "Verify that security findings focus on exploitable risk and credential exposure.",
+  "cases": [
+    {
+      "name": "detects secret handling risk",
+      "input": "A diff adds process.env.SECRET_TOKEN to a child process environment.",
+      "expected": ["credential exposure", "least privilege"]
+    }
+  ]
+}

--- a/tests/evaluation/security-reviewer.test.json
+++ b/tests/evaluation/security-reviewer.test.json
@@ -1,0 +1,11 @@
+{
+  "id": "security-reviewer",
+  "purpose": "Verify that the reviewer critiques other agents through a security lens.",
+  "cases": [
+    {
+      "name": "reviews performance advice for secret leakage",
+      "input": "A performance suggestion expands child process environment forwarding.",
+      "expected": ["security tradeoff", "least privilege"]
+    }
+  ]
+}

--- a/tests/evaluation/sre-agent.test.json
+++ b/tests/evaluation/sre-agent.test.json
@@ -1,0 +1,11 @@
+{
+  "id": "sre-agent",
+  "purpose": "Verify that reliability findings cover timeouts, resource limits, and operational failure modes.",
+  "cases": [
+    {
+      "name": "detects unbounded IO",
+      "input": "A command reads every changed file without total byte limits.",
+      "expected": ["resource limit", "operational safety"]
+    }
+  ]
+}

--- a/tests/evaluation/test-strategist.test.json
+++ b/tests/evaluation/test-strategist.test.json
@@ -1,0 +1,16 @@
+{
+  "id": "test-strategist",
+  "purpose": "Verify that test findings require regression coverage for behavior and CI semantics.",
+  "cases": [
+    {
+      "name": "detects CI green on fail verdict",
+      "input": "A workflow runs alex ci without --fail-on-fail.",
+      "expected": ["failing check", "workflow regression test"]
+    },
+    {
+      "name": "stays silent when tests are unaffected",
+      "input": "A README typo is fixed without touching runtime code, contracts, workflows, or tests.",
+      "expected": ["no finding"]
+    }
+  ]
+}

--- a/tests/unit/agent_parser.test.mjs
+++ b/tests/unit/agent_parser.test.mjs
@@ -1,0 +1,124 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  ALL_AGENT_IDS,
+  DEFAULT_AGENT_IDS,
+} from '../../dist/agents/catalog.js';
+import {
+  resolveAgentIds,
+} from '../../dist/agents/agent_parser.js';
+import {
+  buildArchitectConsolidatorInstruction,
+} from '../../dist/prompts/index.js';
+import {
+  createRootAgent,
+} from '../../dist/agent.js';
+
+test('resolveAgentIds expands default without opt-in agents', () => {
+  const resolved = resolveAgentIds({ agents: 'default' });
+
+  assert.deepEqual(resolved, [...DEFAULT_AGENT_IDS]);
+  assert.equal(resolved.includes('test-strategist'), false);
+});
+
+test('resolveAgentIds supports comma or space separated opt-in agents', () => {
+  const resolved = resolveAgentIds({
+    agents: 'default test-strategist,error-handling-specialist',
+  });
+
+  assert.equal(resolved.includes('test-strategist'), true);
+  assert.equal(resolved.includes('error-handling-specialist'), true);
+});
+
+test('review command exposes optional profile shortcut', async () => {
+  const { execFileSync } = await import('node:child_process');
+  const help = execFileSync(process.execPath, ['dist/cli.js', 'review', '--help'], {
+    encoding: 'utf8',
+  });
+
+  assert.match(help, /review \[options\] \[profile\]/);
+});
+
+test('resolveAgentIds expands all to every registered agent', () => {
+  const resolved = resolveAgentIds({ agents: 'all' });
+
+  assert.deepEqual(resolved, [...ALL_AGENT_IDS]);
+  assert.equal(resolved.includes('test-strategist'), true);
+  assert.equal(resolved.includes('performance-reviewer'), false);
+});
+
+test('resolveAgentIds rejects reviewer ids because users configure only agent catalogs', () => {
+  assert.throws(
+    () => resolveAgentIds({ agents: 'security-reviewer' }),
+    /Agente desconhecido/,
+  );
+});
+
+test('resolveAgentIds rejects unknown enabled agents', () => {
+  assert.throws(
+    () => resolveAgentIds({ agents: 'default,missing-agent' }),
+    /Agente desconhecido/,
+  );
+});
+
+test('resolveAgentIds ignores unknown disabled agents for forward-compatible profiles', () => {
+  const resolved = resolveAgentIds({
+    agents: 'security-auditor',
+    disabledAgents: 'future-agent',
+  });
+
+  assert.deepEqual(resolved, ['security-auditor']);
+});
+
+test('resolveAgentIds removes disabled agents and keeps at least one council agent', () => {
+  const resolved = resolveAgentIds({
+    agents: 'security-auditor,clean-coder,sre-agent',
+    disabledAgents: 'clean-coder',
+  });
+
+  assert.deepEqual(resolved, ['security-auditor', 'sre-agent']);
+});
+
+test('resolveAgentIds rejects an empty agent profile', () => {
+  assert.throws(
+    () => resolveAgentIds({ agents: 'security-auditor', disabledAgents: 'security-auditor' }),
+    /nenhum agente de analise/,
+  );
+});
+
+test('buildArchitectConsolidatorInstruction uses only provided output keys', () => {
+  const instruction = buildArchitectConsolidatorInstruction(
+    '- Testes: {test_findings?}',
+    '(fase de reflexao desabilitada)',
+  );
+
+  assert.match(instruction, /test_findings/);
+  assert.doesNotMatch(instruction, /security_findings/);
+});
+
+test('createRootAgent derives reviewers when their agent dependencies are present', () => {
+  const agent = createRootAgent('test-model', {
+    enabledAgents: ['security-auditor', 'clean-coder', 'sre-agent'],
+  });
+  const stageNames = agent.subAgents.flatMap((stage) => [
+    stage.name,
+    ...(stage.subAgents ?? []).map((subAgent) => subAgent.name),
+  ]);
+
+  assert.equal(stageNames.includes('security-reviewer'), true);
+  assert.equal(stageNames.includes('performance-reviewer'), true);
+});
+
+test('createRootAgent skips reviewers when their agent dependencies are absent', () => {
+  const agent = createRootAgent('test-model', {
+    enabledAgents: ['security-auditor'],
+  });
+  const stageNames = agent.subAgents.flatMap((stage) => [
+    stage.name,
+    ...(stage.subAgents ?? []).map((subAgent) => subAgent.name),
+  ]);
+
+  assert.equal(stageNames.includes('security-auditor'), true);
+  assert.equal(stageNames.includes('security-reviewer'), false);
+  assert.equal(stageNames.includes('performance-reviewer'), false);
+});

--- a/tests/unit/config.test.mjs
+++ b/tests/unit/config.test.mjs
@@ -6,29 +6,46 @@ import path from 'node:path';
 
 test('user config stores API key and model under the user home', async () => {
   const originalHome = process.env.USERPROFILE;
+  const originalPosixHome = process.env.HOME;
   const originalGemini = process.env.GEMINI_API_KEY;
   const originalModel = process.env.ALEX_MODEL;
+  const originalAgents = process.env.ALEX_AGENTS;
+  const originalDisabledAgents = process.env.ALEX_DISABLED_AGENTS;
   const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'alex-home-'));
 
   try {
     delete process.env.GEMINI_API_KEY;
     delete process.env.ALEX_MODEL;
+    delete process.env.ALEX_AGENTS;
+    delete process.env.ALEX_DISABLED_AGENTS;
     process.env.USERPROFILE = tempHome;
+    process.env.HOME = tempHome;
 
     const configModule = await import(`../../dist/config.js?case=${Date.now()}`);
     configModule.updateUserConfig({
       geminiApiKey: 'test-key',
       model: 'gemini-test-model',
+      agents: 'default,test-strategist',
+      disabledAgents: 'docs-maintainer',
     });
 
     assert.equal(configModule.getGeminiApiKey(), 'test-key');
     assert.equal(configModule.getDefaultModel(), 'gemini-test-model');
     assert.equal(fs.existsSync(configModule.getConfigPath()), true);
+
+    configModule.applyStoredConfigToEnv();
+    assert.equal(process.env.ALEX_AGENTS, 'default,test-strategist');
+    assert.equal(process.env.ALEX_DISABLED_AGENTS, 'docs-maintainer');
   } finally {
     if (originalHome === undefined) {
       delete process.env.USERPROFILE;
     } else {
       process.env.USERPROFILE = originalHome;
+    }
+    if (originalPosixHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalPosixHome;
     }
     if (originalGemini === undefined) {
       delete process.env.GEMINI_API_KEY;
@@ -39,6 +56,93 @@ test('user config stores API key and model under the user home', async () => {
       delete process.env.ALEX_MODEL;
     } else {
       process.env.ALEX_MODEL = originalModel;
+    }
+    if (originalAgents === undefined) {
+      delete process.env.ALEX_AGENTS;
+    } else {
+      process.env.ALEX_AGENTS = originalAgents;
+    }
+    if (originalDisabledAgents === undefined) {
+      delete process.env.ALEX_DISABLED_AGENTS;
+    } else {
+      process.env.ALEX_DISABLED_AGENTS = originalDisabledAgents;
+    }
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('stored config does not override explicit empty agent env vars', async () => {
+  const originalHome = process.env.USERPROFILE;
+  const originalPosixHome = process.env.HOME;
+  const originalAgents = process.env.ALEX_AGENTS;
+  const originalDisabledAgents = process.env.ALEX_DISABLED_AGENTS;
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'alex-home-'));
+
+  try {
+    process.env.USERPROFILE = tempHome;
+    process.env.HOME = tempHome;
+    process.env.ALEX_AGENTS = '';
+    process.env.ALEX_DISABLED_AGENTS = '';
+
+    const configModule = await import(`../../dist/config.js?case=empty-${Date.now()}`);
+    configModule.updateUserConfig({
+      agents: 'all',
+      disabledAgents: 'docs-maintainer',
+    });
+    configModule.applyStoredConfigToEnv();
+
+    assert.equal(process.env.ALEX_AGENTS, '');
+    assert.equal(process.env.ALEX_DISABLED_AGENTS, '');
+  } finally {
+    if (originalHome === undefined) {
+      delete process.env.USERPROFILE;
+    } else {
+      process.env.USERPROFILE = originalHome;
+    }
+    if (originalPosixHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalPosixHome;
+    }
+    if (originalAgents === undefined) {
+      delete process.env.ALEX_AGENTS;
+    } else {
+      process.env.ALEX_AGENTS = originalAgents;
+    }
+    if (originalDisabledAgents === undefined) {
+      delete process.env.ALEX_DISABLED_AGENTS;
+    } else {
+      process.env.ALEX_DISABLED_AGENTS = originalDisabledAgents;
+    }
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('corrupted user config is ignored instead of crashing startup', async () => {
+  const originalHome = process.env.USERPROFILE;
+  const originalPosixHome = process.env.HOME;
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'alex-home-'));
+
+  try {
+    process.env.USERPROFILE = tempHome;
+    process.env.HOME = tempHome;
+
+    const configPath = path.join(tempHome, '.alex', 'config.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, '{not valid json', 'utf8');
+
+    const configModule = await import(`../../dist/config.js?case=corrupted-${Date.now()}`);
+    assert.deepEqual(configModule.readUserConfig(), {});
+  } finally {
+    if (originalHome === undefined) {
+      delete process.env.USERPROFILE;
+    } else {
+      process.env.USERPROFILE = originalHome;
+    }
+    if (originalPosixHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalPosixHome;
     }
     fs.rmSync(tempHome, { recursive: true, force: true });
   }

--- a/tests/unit/contracts.test.mjs
+++ b/tests/unit/contracts.test.mjs
@@ -4,10 +4,24 @@ import {
   AnalysisPayloadSchema,
   FinalReportSchema,
   MAX_ANALYSIS_CONTENT_LENGTH,
+  MAX_AGENT_PROFILE_ITEMS,
+  MAX_AGENT_PROFILE_ITEM_LENGTH,
 } from '../../dist/schemas/contracts.js';
 
 test('AnalysisPayloadSchema accepts API payload without streamId or metadata', () => {
   const validation = AnalysisPayloadSchema.safeParse({
+    diff: 'diff --git a/a.ts b/a.ts',
+  });
+
+  assert.equal(validation.success, true);
+});
+
+test('AnalysisPayloadSchema accepts dynamic agent profile metadata', () => {
+  const validation = AnalysisPayloadSchema.safeParse({
+    metadata: {
+      agents: ['default', 'test-strategist'],
+      disabledAgents: ['docs-maintainer'],
+    },
     diff: 'diff --git a/a.ts b/a.ts',
   });
 
@@ -25,6 +39,28 @@ test('AnalysisPayloadSchema rejects payloads without diff or sourceCode', () => 
 test('AnalysisPayloadSchema rejects oversized analysis content', () => {
   const validation = AnalysisPayloadSchema.safeParse({
     diff: 'a'.repeat(MAX_ANALYSIS_CONTENT_LENGTH + 1),
+  });
+
+  assert.equal(validation.success, false);
+});
+
+test('AnalysisPayloadSchema rejects oversized agent profile arrays', () => {
+  const validation = AnalysisPayloadSchema.safeParse({
+    metadata: {
+      agents: Array.from({ length: MAX_AGENT_PROFILE_ITEMS + 1 }, () => 'clean-coder'),
+    },
+    diff: 'diff --git a/a.ts b/a.ts',
+  });
+
+  assert.equal(validation.success, false);
+});
+
+test('AnalysisPayloadSchema rejects oversized agent profile items', () => {
+  const validation = AnalysisPayloadSchema.safeParse({
+    metadata: {
+      agents: ['a'.repeat(MAX_AGENT_PROFILE_ITEM_LENGTH + 1)],
+    },
+    diff: 'diff --git a/a.ts b/a.ts',
   });
 
   assert.equal(validation.success, false);

--- a/tests/unit/evaluation_catalog.test.mjs
+++ b/tests/unit/evaluation_catalog.test.mjs
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { AGENT_CATALOG, REVIEWER_CATALOG } from '../../dist/agents/catalog.js';
+
+test('every catalog entry has an evaluation fixture', () => {
+  const ids = [
+    ...AGENT_CATALOG.map((agent) => agent.id),
+    ...REVIEWER_CATALOG.map((reviewer) => reviewer.id),
+  ];
+
+  for (const id of ids) {
+    const filePath = path.join('tests', 'evaluation', `${id}.test.json`);
+    assert.equal(fs.existsSync(filePath), true, `${filePath} should exist`);
+
+    const fixture = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    assert.equal(fixture.id, id);
+    assert.ok(Array.isArray(fixture.cases));
+    assert.ok(fixture.cases.length > 0);
+  }
+});

--- a/tests/unit/orchestrator_retry.test.mjs
+++ b/tests/unit/orchestrator_retry.test.mjs
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  AdkPipelineError,
+  ReviewOrchestrator,
+  isRetryablePipelineError,
+} from '../../dist/orchestrator.js';
+
+test('isRetryablePipelineError treats transient ADK provider failures as retryable', () => {
+  assert.equal(isRetryablePipelineError(new AdkPipelineError('business-proxy', '502', 'Bad Gateway')), true);
+  assert.equal(isRetryablePipelineError(new AdkPipelineError('business-proxy', 'UNKNOWN_ERROR', 'fetch failed')), true);
+});
+
+test('isRetryablePipelineError does not retry contract or payload failures', () => {
+  assert.equal(isRetryablePipelineError(new AdkPipelineError('business-proxy', '400', 'Invalid request')), false);
+  assert.equal(isRetryablePipelineError(new Error('Contrato de resposta invalido')), false);
+});
+
+test('ReviewOrchestrator retries transient pipeline failures for single-agent profiles', async () => {
+  const originalRetries = process.env.ALEX_AGENT_MAX_RETRIES;
+  const originalBase = process.env.ALEX_AGENT_RETRY_BASE_MS;
+
+  try {
+    process.env.ALEX_AGENT_MAX_RETRIES = '1';
+    process.env.ALEX_AGENT_RETRY_BASE_MS = '0';
+
+    const orchestrator = new ReviewOrchestrator('test-model', {
+      enabledAgents: ['security-auditor'],
+    });
+    let attempts = 0;
+    orchestrator.runPipelineOnce = async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new AdkPipelineError('security-auditor', '502', 'Bad Gateway');
+      }
+      return JSON.stringify({
+        streamId: '550e8400-e29b-41d4-a716-446655440000',
+        verdict: 'PASS',
+        summary: 'ok',
+        issues: [],
+        timestamp: '2026-04-24T19:00:00.000Z',
+      });
+    };
+
+    const result = await orchestrator.analyze({
+      streamId: '550e8400-e29b-41d4-a716-446655440000',
+      diff: 'diff --git a/a.ts b/a.ts',
+    });
+
+    assert.equal(attempts, 2);
+    assert.match(result, /"verdict":"PASS"/);
+  } finally {
+    if (originalRetries === undefined) {
+      delete process.env.ALEX_AGENT_MAX_RETRIES;
+    } else {
+      process.env.ALEX_AGENT_MAX_RETRIES = originalRetries;
+    }
+    if (originalBase === undefined) {
+      delete process.env.ALEX_AGENT_RETRY_BASE_MS;
+    } else {
+      process.env.ALEX_AGENT_RETRY_BASE_MS = originalBase;
+    }
+  }
+});

--- a/tests/unit/retry_policy.test.mjs
+++ b/tests/unit/retry_policy.test.mjs
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  getAgentRetryConfig,
+  getPipelineRetryConfig,
+  getRetryDelayMs,
+  isTransientAgentError,
+} from '../../dist/agents/retry_policy.js';
+
+test('isTransientAgentError detects retryable provider failures', () => {
+  assert.equal(isTransientAgentError('502', 'Bad Gateway'), true);
+  assert.equal(isTransientAgentError('429', 'Too Many Requests'), true);
+  assert.equal(isTransientAgentError('UNKNOWN_ERROR', 'socket hang up'), true);
+  assert.equal(isTransientAgentError('UNKNOWN_ERROR', 'fetch failed'), true);
+  assert.equal(isTransientAgentError('400', 'Invalid request payload'), false);
+  assert.equal(isTransientAgentError(undefined, undefined), false);
+});
+
+test('getAgentRetryConfig clamps env configuration', async () => {
+  const originalRetries = process.env.ALEX_AGENT_MAX_RETRIES;
+  const originalBase = process.env.ALEX_AGENT_RETRY_BASE_MS;
+
+  try {
+    process.env.ALEX_AGENT_MAX_RETRIES = '99';
+    process.env.ALEX_AGENT_RETRY_BASE_MS = '15';
+
+    assert.deepEqual(getAgentRetryConfig(), {
+      maxRetries: 5,
+      baseDelayMs: 15,
+    });
+  } finally {
+    if (originalRetries === undefined) {
+      delete process.env.ALEX_AGENT_MAX_RETRIES;
+    } else {
+      process.env.ALEX_AGENT_MAX_RETRIES = originalRetries;
+    }
+    if (originalBase === undefined) {
+      delete process.env.ALEX_AGENT_RETRY_BASE_MS;
+    } else {
+      process.env.ALEX_AGENT_RETRY_BASE_MS = originalBase;
+    }
+  }
+});
+
+test('getRetryDelayMs applies exponential backoff with bounded jitter', () => {
+  const delay = getRetryDelayMs(2, 100);
+
+  assert.equal(delay >= 200, true);
+  assert.equal(delay < 225, true);
+});
+
+test('getPipelineRetryConfig disables retry storms for multi-agent profiles by default', () => {
+  const originalRetries = process.env.ALEX_AGENT_MAX_RETRIES;
+  const originalAllow = process.env.ALEX_ALLOW_MULTI_AGENT_PIPELINE_RETRY;
+
+  try {
+    process.env.ALEX_AGENT_MAX_RETRIES = '2';
+    delete process.env.ALEX_ALLOW_MULTI_AGENT_PIPELINE_RETRY;
+
+    assert.equal(getPipelineRetryConfig(1).maxRetries, 2);
+    assert.equal(getPipelineRetryConfig(4).maxRetries, 0);
+
+    process.env.ALEX_ALLOW_MULTI_AGENT_PIPELINE_RETRY = 'true';
+    assert.equal(getPipelineRetryConfig(4).maxRetries, 2);
+  } finally {
+    if (originalRetries === undefined) {
+      delete process.env.ALEX_AGENT_MAX_RETRIES;
+    } else {
+      process.env.ALEX_AGENT_MAX_RETRIES = originalRetries;
+    }
+    if (originalAllow === undefined) {
+      delete process.env.ALEX_ALLOW_MULTI_AGENT_PIPELINE_RETRY;
+    } else {
+      process.env.ALEX_ALLOW_MULTI_AGENT_PIPELINE_RETRY = originalAllow;
+    }
+  }
+});

--- a/tests/unit/workflow_profiles.test.mjs
+++ b/tests/unit/workflow_profiles.test.mjs
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import YAML from 'yaml';
+
+const workflowPaths = [
+  '.github/workflows/alex-pr-review.yml',
+  '.github/workflows/alex-pr-review.consumer.yml',
+];
+
+test('GitHub workflows pass dynamic agent profile variables to alex ci', () => {
+  for (const workflowPath of workflowPaths) {
+    const source = fs.readFileSync(workflowPath, 'utf8');
+    const workflow = YAML.parse(source);
+    const steps = workflow.jobs['alex-pr-review'].steps;
+    const profileStep = steps.find((step) => step.id === 'agent-profile');
+    const runStep = steps.find((step) => step.run?.includes('--diff-file pr.diff'));
+
+    assert.ok(profileStep, `${workflowPath} should resolve comment agent profile`);
+    assert.equal(profileStep.env.DEFAULT_ALEX_AGENTS, "${{ vars.ALEX_AGENTS || 'default' }}");
+    assert.equal(profileStep.env.DEFAULT_ALEX_DISABLED_AGENTS, "${{ vars.ALEX_DISABLED_AGENTS || '' }}");
+    assert.match(profileStep.with.script, /readOption\('agents'\)/);
+    assert.match(profileStep.with.script, /readOption\('disable-agents'\)/);
+    assert.match(profileStep.with.script, /restTokens\.length === 1/);
+    assert.match(profileStep.with.script, /core\.warning/);
+    assert.match(profileStep.with.script, /alex\\s\+review/);
+    assert.ok(runStep, `${workflowPath} should run alex ci`);
+    assert.equal(runStep.env.ALEX_AGENTS, "${{ steps.agent-profile.outputs.agents }}");
+    assert.equal(runStep.env.ALEX_DISABLED_AGENTS, "${{ steps.agent-profile.outputs.disabled-agents }}");
+    assert.equal(runStep.env.REPORT_PATH, '${{ runner.temp }}/alex-review.md');
+    assert.match(runStep.run, /--agents "\$ALEX_AGENTS"/);
+    assert.match(runStep.run, /--disable-agents "\$ALEX_DISABLED_AGENTS"/);
+    assert.match(runStep.run, /--fail-on-fail/);
+    assert.match(runStep.run, /--output-file "\$REPORT_PATH"/);
+  }
+});
+
+test('Internal workflow runs trusted A.L.E.X build outside the PR checkout', () => {
+  const source = fs.readFileSync('.github/workflows/alex-pr-review.yml', 'utf8');
+  const workflow = YAML.parse(source);
+  const steps = workflow.jobs['alex-pr-review'].steps;
+
+  const trustedCheckout = steps.find((step) => step.name === 'Checkout trusted A.L.E.X source');
+  const targetCheckout = steps.find((step) => step.name === 'Checkout PR analysis target');
+  const installStep = steps.find((step) => step.name === 'Install trusted A.L.E.X dependencies');
+  const buildStep = steps.find((step) => step.name === 'Build trusted A.L.E.X');
+  const runStep = steps.find((step) => step.name === 'Run A.L.E.X CI review');
+  const diffStep = steps.find((step) => step.name === 'Capture PR diff');
+  const commentStep = steps.find((step) => step.name === 'Comment review on PR');
+
+  assert.equal(trustedCheckout.with.path, 'alex-tool');
+  assert.equal(trustedCheckout.with.ref, '${{ github.event.repository.default_branch }}');
+  assert.equal(targetCheckout.with.path, 'pr-target');
+  assert.equal(installStep['working-directory'], 'alex-tool');
+  assert.equal(buildStep['working-directory'], 'alex-tool');
+  assert.match(diffStep.run, /rm -f pr\.diff "\$RUNNER_TEMP\/alex-review\.md"/);
+  assert.equal(runStep['working-directory'], 'pr-target');
+  assert.match(runStep.run, /node \.\.\/alex-tool\/dist\/cli\.js ci/);
+  assert.equal(commentStep.if, "always() && steps.permission.outputs.allowed == 'true'");
+  assert.equal(commentStep.env.REPORT_PATH, '${{ runner.temp }}/alex-review.md');
+  assert.match(commentStep.with.script, /fs\.existsSync\(reportPath\)/);
+  assert.doesNotMatch(commentStep.with.script, /pr-target\/alex-review\.md/);
+});


### PR DESCRIPTION
- Add src/agents/catalog.ts: central typed catalog with AgentId, AgentDefinition, ReviewerDefinition, AGENT_CATALOG, REVIEWER_CATALOG, DEFAULT_AGENT_IDS, ALL_AGENT_IDS and lookup helpers

- Add src/agents/agent_parser.ts: pure resolveAgentIds() with default/all expansion, unknown-ID validation, disabledAgents removal and empty-council guard; accepts comma or space as separators (PowerShell compat)

- Expand AgentId to include 5 new planned agents (error-handling-specialist, test-strategist, observability-engineer, docs-maintainer, scalability-architect) and move reviewers to ReviewerDefinition with requiresAgentIds dependency model

- Update src/agent.ts: createRootAgent(model, { enabledAgents }) builds council and reflection stages dynamically from catalog; reviewers are derived automatically based on which analysis agents are enabled

- Update src/orchestrator.ts: ReviewOrchestrator accepts enabledAgents option and forwards to createRootAgent

- Update src/cli.ts:
  - Add --agents and --disable-agents to review, analyze and ci commands
  - Read ALEX_AGENTS / ALEX_DISABLED_AGENTS env vars with CLI precedence
  - Add config set-agents and config disable-agent subcommands
  - Add resolveAgentsOrExit and failAnalysis helpers (DRY)
  - Switch review to getLocalReviewDiff (tracked + untracked files)
  - Add LlmResultParseError handling with truncated raw output

- Update src/config.ts: UserConfigSchema adds agents and disabledAgents fields

- Add BACKLOG_AGENT_TRIAGE.md: rule-based automatic agent triage backlog (PR 3)

- Update README: architecture section with full 11-agent catalog table, dynamic selection docs and updated project structure